### PR TITLE
Improve Authorize.Net charge logging

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -8,15 +8,15 @@ This feature is intended for development only. Before deploying to production, c
 
 The General Settings tab also provides an **Authorize.net testing** button. Clicking it triggers a series of automated purchases through the plugin's AJAX endpoints using your sandbox credentials. Each scenario (single ticket, multiple tickets, membership only, and membership plus tickets) runs with short delays to avoid API throttling. Progress and results for every step are written to the debug log.
 
-All Authorize.Net API responses are logged to the PHP `error_log`, making it easy to inspect the full payload returned by the gateway after any checkout attempt. The debug log also records key `TransactionResponse` fields—such as the response code and any error messages—so declines clearly show their specific reason in both sandbox and live modes.
+All Authorize.Net API responses are logged to the PHP `error_log`, making it easy to inspect the full payload returned by the gateway after any checkout attempt. The debug log also records key `TransactionResponse` fields—response codes, transaction IDs, auth codes, AVS/CVV results, masked account numbers, and any error messages—so declines clearly show their specific reason in both sandbox and live modes.
 
 ## Authorize.Net request/response logging
 
-Every transaction attempt records a sanitized snapshot of the request and response payloads. Sensitive values such as API Login IDs, Transaction Keys, and card numbers are partially masked (only the last four digits of a card are shown) and CVV codes are never logged. Example entry:
+Every transaction attempt records the exact JSON payload sent to Authorize.Net along with the response payload. Sensitive values such as API Login IDs, Transaction Keys, and card numbers are partially masked (only the last four digits of a card are shown) and CVV codes are never logged. Example entry:
 
 ```
-charge request: {"api_login_id":"LOGI****3456","card_number":"************1111","card_code":"[omitted]"}
-charge response: {"transactionResponse":{"responseCode":"2","errors":[{"errorCode":"54","errorText":"Card expired"}]}}
+charge request (https://api.authorize.net): {"createTransactionRequest":{"merchantAuthentication":{"name":"LOGI****3456","transactionKey":"TRAN****5678"},"transactionRequest":{"transactionType":"authCaptureTransaction","amount":10,"payment":{"creditCard":{"cardNumber":"************1111","expirationDate":"2025-12","cardCode":"[omitted]"}},"billTo":{"firstName":"John","lastName":"Doe"}}}}
+charge transactionResponse: {"responseCode":"2","transId":"123456","authCode":"ABC123","avsResultCode":"N","cvvResultCode":"P","accountNumber":"************1111","errors":{"errorCode":"54","errorText":"Card expired"}}
 ```
 
 Clear the log regularly in production environments to avoid retaining outdated debugging information.

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -9,3 +9,14 @@ This feature is intended for development only. Before deploying to production, c
 The General Settings tab also provides an **Authorize.net testing** button. Clicking it triggers a series of automated purchases through the plugin's AJAX endpoints using your sandbox credentials. Each scenario (single ticket, multiple tickets, membership only, and membership plus tickets) runs with short delays to avoid API throttling. Progress and results for every step are written to the debug log.
 
 All Authorize.Net API responses are logged to the PHP `error_log`, making it easy to inspect the full payload returned by the gateway after any checkout attempt. The debug log also records key `TransactionResponse` fields—such as the response code and any error messages—so declines clearly show their specific reason in both sandbox and live modes.
+
+## Authorize.Net request/response logging
+
+Every transaction attempt records a sanitized snapshot of the request and response payloads. Sensitive values such as API Login IDs, Transaction Keys, and card numbers are partially masked (only the last four digits of a card are shown) and CVV codes are never logged. Example entry:
+
+```
+charge request: {"api_login_id":"LOGI****3456","card_number":"************1111","card_code":"[omitted]"}
+charge response: {"transactionResponse":{"responseCode":"2","errors":[{"errorCode":"54","errorText":"Card expired"}]}}
+```
+
+Clear the log regularly in production environments to avoid retaining outdated debugging information.

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -8,4 +8,4 @@ This feature is intended for development only. Before deploying to production, c
 
 The General Settings tab also provides an **Authorize.net testing** button. Clicking it triggers a series of automated purchases through the plugin's AJAX endpoints using your sandbox credentials. Each scenario (single ticket, multiple tickets, membership only, and membership plus tickets) runs with short delays to avoid API throttling. Progress and results for every step are written to the debug log.
 
-All Authorize.Net API responses are logged to the PHP `error_log`, making it easy to inspect the full payload returned by the gateway after any checkout attempt.
+All Authorize.Net API responses are logged to the PHP `error_log`, making it easy to inspect the full payload returned by the gateway after any checkout attempt. The debug log also records key `TransactionResponse` fields—such as the response code and any error messages—so declines clearly show their specific reason in both sandbox and live modes.

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -12,10 +12,10 @@ All Authorize.Net API responses are logged to the PHP `error_log`, making it eas
 
 ## Authorize.Net request/response logging
 
-Every transaction attempt records the exact JSON payload sent to Authorize.Net along with the response payload. Sensitive values such as API Login IDs, Transaction Keys, and card numbers are partially masked (only the last four digits of a card are shown) and CVV codes are never logged. Example entry:
+Every transaction attempt records the exact JSON payload sent to Authorize.Net along with the response payload. Sensitive values such as API Login IDs, Transaction Keys, and card numbers are partially masked (only the last four digits of a card are shown) and CVV codes are never logged. Billing details include the full address and default country (`USA`), and amounts are formatted as two-decimal strings. Example entry:
 
 ```
-charge request (https://api.authorize.net): {"createTransactionRequest":{"merchantAuthentication":{"name":"LOGI****3456","transactionKey":"TRAN****5678"},"transactionRequest":{"transactionType":"authCaptureTransaction","amount":10,"payment":{"creditCard":{"cardNumber":"************1111","expirationDate":"2025-12","cardCode":"[omitted]"}},"billTo":{"firstName":"John","lastName":"Doe"}}}}
+charge request (https://api.authorize.net): {"createTransactionRequest":{"merchantAuthentication":{"name":"LOGI****3456","transactionKey":"TRAN****5678"},"transactionRequest":{"transactionType":"authCaptureTransaction","amount":"10.00","payment":{"creditCard":{"cardNumber":"************1111","expirationDate":"2025-12","cardCode":"[omitted]"}},"billTo":{"firstName":"John","lastName":"Doe","address":"123 St","city":"Richmond","state":"VA","zip":"23220","country":"USA"}}}}
 charge transactionResponse: {"responseCode":"2","transId":"123456","authCode":"ABC123","avsResultCode":"N","cvvResultCode":"P","accountNumber":"************1111","errors":{"errorCode":"54","errorText":"Card expired"}}
 ```
 

--- a/includes/api/class-authorizenet-api.php
+++ b/includes/api/class-authorizenet-api.php
@@ -243,6 +243,8 @@ class TTA_AuthorizeNet_API {
             return [ 'success' => false, 'error' => 'Authorize.Net credentials not configured' ];
         }
 
+        $amount = number_format( (float) $amount, 2, '.', '' );
+
         $merchantAuthentication = new AnetAPI\MerchantAuthenticationType();
         $merchantAuthentication->setName( $this->login_id );
         $merchantAuthentication->setTransactionKey( $this->transaction_key );
@@ -262,12 +264,13 @@ class TTA_AuthorizeNet_API {
 
         if ( $billing ) {
             $address = new AnetAPI\CustomerAddressType();
-            $address->setFirstName( $billing['first_name'] ?? '' );
-            $address->setLastName( $billing['last_name'] ?? '' );
-            $address->setAddress( $billing['address'] ?? '' );
-            $address->setCity( $billing['city'] ?? '' );
-            $address->setState( $billing['state'] ?? '' );
-            $address->setZip( $billing['zip'] ?? '' );
+            $address->setFirstName( sanitize_text_field( $billing['first_name'] ?? '' ) );
+            $address->setLastName( sanitize_text_field( $billing['last_name'] ?? '' ) );
+            $address->setAddress( sanitize_text_field( $billing['address'] ?? '' ) );
+            $address->setCity( sanitize_text_field( $billing['city'] ?? '' ) );
+            $address->setState( sanitize_text_field( $billing['state'] ?? '' ) );
+            $address->setZip( sanitize_text_field( $billing['zip'] ?? '' ) );
+            $address->setCountry( sanitize_text_field( $billing['country'] ?? 'USA' ) );
             $transactionRequest->setBillTo( $address );
         }
 
@@ -281,6 +284,9 @@ class TTA_AuthorizeNet_API {
         $sanitized    = $this->sanitize_response_array( json_decode( wp_json_encode( $request_json ), true ) );
         if ( isset( $sanitized[ $root ]['merchantAuthentication']['name'] ) ) {
             $sanitized[ $root ]['merchantAuthentication']['name'] = $this->mask_value( (string) $sanitized[ $root ]['merchantAuthentication']['name'] );
+        }
+        if ( isset( $sanitized[ $root ]['transactionRequest']['amount'] ) ) {
+            $sanitized[ $root ]['transactionRequest']['amount'] = number_format( (float) $sanitized[ $root ]['transactionRequest']['amount'], 2, '.', '' );
         }
         array_walk_recursive( $sanitized, function ( &$v ) {
             if ( is_string( $v ) ) {

--- a/tests/AuthorizeNetLoggingTest.php
+++ b/tests/AuthorizeNetLoggingTest.php
@@ -1,0 +1,85 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class AuthorizeNetLoggingTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['options'] = [];
+        if ( ! function_exists( 'get_option' ) ) {
+            function get_option( $k, $d = false ) { return $GLOBALS['options'][ $k ] ?? $d; }
+        }
+        if ( ! function_exists( 'update_option' ) ) {
+            function update_option( $k, $v, $autoload = true ) { $GLOBALS['options'][ $k ] = $v; }
+        }
+        if ( ! function_exists( 'delete_option' ) ) {
+            function delete_option( $k ) { unset( $GLOBALS['options'][ $k ] ); }
+        }
+        if ( ! defined( 'ABSPATH' ) ) {
+            define( 'ABSPATH', sys_get_temp_dir() . '/wp/' );
+        }
+        require_once __DIR__ . '/../vendor/autoload.php';
+        require_once __DIR__ . '/../includes/classes/class-tta-debug-logger.php';
+        require_once __DIR__ . '/../includes/api/class-authorizenet-api.php';
+    }
+
+    protected function make_response() {
+        $tresponse = new class {
+            public function getResponseCode() { return '2'; }
+            public function getErrors() {
+                return [ new class {
+                    public function getErrorCode() { return '54'; }
+                    public function getErrorText() { return 'Card expired'; }
+                } ];
+            }
+            public function getMessages() { return []; }
+        };
+
+        return new class( $tresponse ) {
+            private $tresponse;
+            public function __construct( $tresponse ) { $this->tresponse = $tresponse; }
+            public function getMessages() {
+                return new class {
+                    public function getResultCode() { return 'Error'; }
+                    public function getMessage() {
+                        return [ new class {
+                            public function getCode() { return 'E00027'; }
+                            public function getText() { return 'The transaction was declined.'; }
+                        } ];
+                    }
+                };
+            }
+            public function getTransactionResponse() { return $this->tresponse; }
+        };
+    }
+
+    public function test_logs_transaction_details_in_sandbox_and_live() {
+        $response = $this->make_response();
+
+        update_option( 'tta_authnet_sandbox', 1 );
+        $api  = new class extends TTA_AuthorizeNet_API {
+            public function log_response_public( $context, $response ) { $this->log_response( $context, $response ); }
+        };
+        TTA_Debug_Logger::clear();
+        $api->log_response_public( 'charge', $response );
+        $msgs = TTA_Debug_Logger::get_messages();
+        $this->assertTrue( $this->contains_decline_detail( $msgs ) );
+
+        update_option( 'tta_authnet_sandbox', 0 );
+        $apiLive = new class extends TTA_AuthorizeNet_API {
+            public function log_response_public( $context, $response ) { $this->log_response( $context, $response ); }
+        };
+        TTA_Debug_Logger::clear();
+        $apiLive->log_response_public( 'charge', $response );
+        $msgsLive = TTA_Debug_Logger::get_messages();
+        $this->assertTrue( $this->contains_decline_detail( $msgsLive ) );
+    }
+
+    protected function contains_decline_detail( array $msgs ) {
+        foreach ( $msgs as $m ) {
+            if ( strpos( $m, '2 54 Card expired' ) !== false ) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+?>

--- a/tests/AuthorizeNetRequestLoggingTest.php
+++ b/tests/AuthorizeNetRequestLoggingTest.php
@@ -30,6 +30,11 @@ class AuthorizeNetRequestLoggingTest extends TestCase {
     protected function make_response() {
         $tresponse = new class {
             public function getResponseCode() { return '2'; }
+            public function getTransId() { return '123456'; }
+            public function getAuthCode() { return 'ABC123'; }
+            public function getAvsResultCode() { return 'N'; }
+            public function getCvvResultCode() { return 'P'; }
+            public function getAccountNumber() { return '4111111111111111'; }
             public function getErrors() {
                 return [ new class {
                     public function getErrorCode() { return '54'; }
@@ -78,7 +83,7 @@ class AuthorizeNetRequestLoggingTest extends TestCase {
         ] );
 
         $log = implode( "\n", TTA_Debug_Logger::get_messages() );
-        $this->assertStringContainsString( 'charge request:', $log );
+        $this->assertStringContainsString( 'charge request', $log );
         $this->assertStringContainsString( 'LOGI', $log );
         $this->assertStringContainsString( '5678', $log );
         $this->assertStringNotContainsString( 'LOGINID123456', $log );

--- a/tests/AuthorizeNetRequestLoggingTest.php
+++ b/tests/AuthorizeNetRequestLoggingTest.php
@@ -90,6 +90,8 @@ class AuthorizeNetRequestLoggingTest extends TestCase {
         $this->assertStringNotContainsString( 'TRANSKEY12345678', $log );
         $this->assertStringContainsString( '************1111', $log );
         $this->assertStringNotContainsString( '4111111111111111', $log );
+        $this->assertStringContainsString( '"amount":"10.00"', $log );
+        $this->assertStringContainsString( '"country":"USA"', $log );
         $this->assertStringContainsString( '[omitted]', $log );
         $this->assertStringNotContainsString( '999', $log );
         $this->assertStringContainsString( 'John', $log );


### PR DESCRIPTION
## Summary
- log Authorize.Net charge `TransactionResponse` codes and messages for easier decline diagnostics
- drop erroneous refund log from charge()
- document and test detailed logging in sandbox and live modes

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit tests` *(fails: session_start errors, undefined variable items)*
- `phpunit tests/AuthorizeNetLoggingTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a609a0dffc83208125aa34a5f7a05b