### PR TITLE
Customize email headers and add Bcc

### DIFF
--- a/docs/EmailSMS.md
+++ b/docs/EmailSMS.md
@@ -197,6 +197,8 @@ returns both values combined in a single string.
 
 ## Email Delivery
 
+All plugin emails are sent from "Trying To Adult" (<noreply@tryingtoadultrva.com>) and automatically Bcc onlineservices@leveluprichmond.com for internal tracking.
+
 All outgoing messages are dispatched by the `TTA_Email_Handler` class. The handler is loaded on plugin init and is responsible for reading the templates saved on the **Email & SMS** page. After a transaction is recorded, `send_purchase_emails()` groups the purchased items by event and emails the **Successful Event Purchase** template. The purchasing member receives one email and each attendee gets a personalized copy where tokens like `{attendee_first_name}` reflect their own information. Duplicate addresses are skipped so each email address only receives one message.
 
 ## SMS Delivery

--- a/includes/email/class-email-customizer.php
+++ b/includes/email/class-email-customizer.php
@@ -1,0 +1,59 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Customizes default WordPress email headers for the plugin.
+ */
+class TTA_Email_Customizer {
+    /**
+     * Register hooks.
+     */
+    public static function init() {
+        add_filter( 'wp_mail_from_name', [ __CLASS__, 'from_name' ] );
+        add_filter( 'wp_mail_from', [ __CLASS__, 'from_email' ] );
+        add_filter( 'wp_mail', [ __CLASS__, 'add_bcc' ] );
+    }
+
+    /**
+     * Set the default sender name.
+     *
+     * @return string Sender name.
+     */
+    public static function from_name() {
+        return 'Trying To Adult';
+    }
+
+    /**
+     * Set the default sender email address.
+     *
+     * @param string $email Original email address.
+     * @return string Sender email address.
+     */
+    public static function from_email( $email ) {
+        return sanitize_email( 'noreply@tryingtoadultrva.com' );
+    }
+
+    /**
+     * Add a Bcc header to every outgoing email.
+     *
+     * @param array $args Mail arguments.
+     * @return array Modified mail arguments.
+     */
+    public static function add_bcc( $args ) {
+        $bcc     = sanitize_email( 'onlineservices@leveluprichmond.com' );
+        $headers = $args['headers'] ?? [];
+
+        if ( is_string( $headers ) && '' !== $headers ) {
+            $headers = explode( "\n", str_replace( "\r\n", "\n", $headers ) );
+        } elseif ( ! is_array( $headers ) ) {
+            $headers = [];
+        }
+
+        $headers[]       = 'Bcc: ' . $bcc;
+        $args['headers'] = $headers;
+
+        return $args;
+    }
+}

--- a/trying-to-adult-management-plugin.php
+++ b/trying-to-adult-management-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Trying To Adult Management Plugin
  * Plugin URI: https://example.com
  * Description: Custom plugin for Members, Events, Tickets management with waitlist, notifications, and Authorize.Net integration.
- * Version: 0.4.5
+ * Version: 0.4.6
  * Author: Your Name
  * Author URI: https://example.com
  * Text Domain: trying-to-adult-management
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Define plugin constants
 define( 'TTA_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TTA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-define( 'TTA_PLUGIN_VERSION', '0.4.5' );
+define( 'TTA_PLUGIN_VERSION', '0.4.6' );
 define( 'TTA_DB_VERSION', '1.11.0' );
 define( 'TTA_BASIC_MEMBERSHIP_PRICE', 5.00 );
 define( 'TTA_PREMIUM_MEMBERSHIP_PRICE', 10.00 );
@@ -151,6 +151,7 @@ require_once TTA_PLUGIN_DIR . 'includes/frontend/class-checkout-page-manager.php
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-events-list-page.php';
 require_once TTA_PLUGIN_DIR . 'includes/api/class-authorizenet-api.php';
 require_once TTA_PLUGIN_DIR . 'includes/email/class-email-handler.php';
+require_once TTA_PLUGIN_DIR . 'includes/email/class-email-customizer.php';
 require_once TTA_PLUGIN_DIR . 'includes/email/class-email-reminders.php';
 require_once TTA_PLUGIN_DIR . 'includes/sms/class-sms-handler.php';
 require_once TTA_PLUGIN_DIR . 'includes/waitlist/class-waitlist.php';
@@ -220,6 +221,7 @@ class TTA_Plugin {
         }
 
         // Notification handlers
+        TTA_Email_Customizer::init();
         TTA_Email_Handler::get_instance();
         TTA_SMS_Handler::get_instance();
         TTA_Email_Reminders::init();


### PR DESCRIPTION
## Summary
- Add `TTA_Email_Customizer` to set default sender name and address and Bcc an internal address on all outgoing mail
- Load the new email customizer during plugin initialization and bump plugin version
- Document default sender and Bcc in email/SMS docs

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac81e381fc83208a041bd472e06194