### PR TITLE
Improve Facebook event sharing

### DIFF
--- a/assets/js/frontend/share/event-share.js
+++ b/assets/js/frontend/share/event-share.js
@@ -1,29 +1,38 @@
 jQuery(function($){
-  function buildMessage(){
+  function buildDefaultMessage(){
     var title = $('.tta-event-title').text().trim();
     var date  = $('.tta-event-date').text().trim();
     var time  = $('.tta-event-time').text().trim();
     var msg   = 'Check out this upcoming Trying To Adult event - ' + title;
-    if(date) msg += ', on ' + date;
-    if(time) msg += ', at ' + time;
-    return encodeURIComponent(msg);
+    if ( date ) {
+      msg += ', on ' + date;
+    }
+    if ( time ) {
+      msg += ', at ' + time;
+    }
+    return msg;
   }
 
-  function openShare(platform){
-    var url   = encodeURIComponent(window.location.href);
-    var message = buildMessage();
+  function openShare(el){
+    var $el      = $(el);
+    var platform = $el.data('platform');
+    var url      = encodeURIComponent($el.data('share-url') || window.location.href);
+    var message  = encodeURIComponent($el.data('share-message') || buildDefaultMessage());
     var shareUrl = '';
-    if(platform === 'facebook'){
+
+    if ( platform === 'facebook' ) {
       shareUrl = 'https://www.facebook.com/sharer/sharer.php?u=' + url + '&quote=' + message;
-    } else if(platform === 'instagram'){
+    } else if ( platform === 'instagram' ) {
       shareUrl = 'https://www.instagram.com/create?caption=' + message + '&url=' + url;
     }
-    if(shareUrl){
+
+    if ( shareUrl ) {
       window.open(shareUrl, 'ttaShare', 'width=600,height=600');
     }
   }
+
   $(document).on('click', '.tta-share-link', function(e){
     e.preventDefault();
-    openShare($(this).data('platform'));
+    openShare(this);
   });
 });

--- a/assets/js/frontend/share/event-share.js
+++ b/assets/js/frontend/share/event-share.js
@@ -3,11 +3,9 @@ jQuery(function($){
     var title = $('.tta-event-title').text().trim();
     var date  = $('.tta-event-date').text().trim();
     var time  = $('.tta-event-time').text().trim();
-    var venue = $('.tta-event-details-icon-after strong:contains("Venue")').next('a').text().trim();
-    var msg = 'Check out this upcoming Trying to Adult event I\'m attending! ' + title;
-    if(date) msg += ' - ' + date;
-    if(time) msg += ' at ' + time;
-    if(venue) msg += ' at ' + venue;
+    var msg   = 'Check out this upcoming Trying To Adult event - ' + title;
+    if(date) msg += ', on ' + date;
+    if(time) msg += ', at ' + time;
     return encodeURIComponent(msg);
   }
 

--- a/docs/EventShare.md
+++ b/docs/EventShare.md
@@ -1,11 +1,18 @@
 # Event Sharing
 
 Event pages feature simple social sharing buttons for Facebook and Instagram.
-The icons appear in the hero section below the event meta list.
-Clicking an icon opens a small share window with the event URL and a short
-message including the event name, date, time and venue. Facebook uses the
-`quote` parameter while Instagram opens its creation screen with the caption
-pre-filled when possible.
+The icons appear in the hero section below the event meta list. Clicking an
+icon opens a small share window with the exact event URL and a short message
+that reads:
+
+```
+Check out this upcoming Trying To Adult event - {Event Name}, on {Event Date}, at {Event Time}
+```
+
+Facebook uses the `quote` parameter while Instagram opens its creation screen
+with the caption pre-filled when possible. The event template also outputs
+Open Graph tags (`og:title`, `og:url`, `og:image`) so that Facebook previews
+the correct permalink and featured image.
 
 JavaScript for this behaviour lives in `assets/js/frontend/share/event-share.js`.
 It is enqueued only when viewing the Event Page template via `TTA_Assets`.

--- a/docs/EventShare.md
+++ b/docs/EventShare.md
@@ -10,9 +10,13 @@ Check out this upcoming Trying To Adult event - {Event Name}, on {Event Date}, a
 ```
 
 Facebook uses the `quote` parameter while Instagram opens its creation screen
-with the caption pre-filled when possible. The event template also outputs
-Open Graph tags (`og:title`, `og:url`, `og:image`) so that Facebook previews
-the correct permalink and featured image.
+with the caption pre-filled when possible. Each share link embeds the event
+permalink and message via `data-share-url` and `data-share-message`
+attributes so the JavaScript does not rely on the browser location.
+
+The event template also outputs Open Graph tags (`og:type`, `og:title`,
+`og:description`, `og:url`, `og:image`) so that Facebook previews the correct
+permalink and featured image.
 
 JavaScript for this behaviour lives in `assets/js/frontend/share/event-share.js`.
 It is enqueued only when viewing the Event Page template via `TTA_Assets`.

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -67,11 +67,11 @@ if ( $event ) {
     );
 
     add_action( 'wp_head', function() use ( $page_id, $event, $share_message_meta, $hero_image_url_meta ) {
-        echo '<meta property="og:title" content="' . esc_attr( $event['name'] ) . "" />\n";
-        echo '<meta property="og:description" content="' . esc_attr( $share_message_meta ) . "" />\n";
-        echo '<meta property="og:url" content="' . esc_url( get_permalink( $page_id ) ) . "" />\n";
+        echo '<meta property="og:title" content="' . esc_attr( $event['name'] ) . '" />' . "\n";
+        echo '<meta property="og:description" content="' . esc_attr( $share_message_meta ) . '" />' . "\n";
+        echo '<meta property="og:url" content="' . esc_url( get_permalink( $page_id ) ) . '" />' . "\n";
         if ( $hero_image_url_meta ) {
-            echo '<meta property="og:image" content="' . esc_url( $hero_image_url_meta ) . "" />\n";
+            echo '<meta property="og:image" content="' . esc_url( $hero_image_url_meta ) . '" />' . "\n";
         }
     } );
 }

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -67,13 +67,14 @@ if ( $event ) {
     );
 
     add_action( 'wp_head', function() use ( $page_id, $event, $share_message_meta, $hero_image_url_meta ) {
+        echo '<meta property="og:type" content="article" />' . "\n";
         echo '<meta property="og:title" content="' . esc_attr( $event['name'] ) . '" />' . "\n";
         echo '<meta property="og:description" content="' . esc_attr( $share_message_meta ) . '" />' . "\n";
         echo '<meta property="og:url" content="' . esc_url( get_permalink( $page_id ) ) . '" />' . "\n";
         if ( $hero_image_url_meta ) {
             echo '<meta property="og:image" content="' . esc_url( $hero_image_url_meta ) . '" />' . "\n";
         }
-    } );
+    }, 1 );
 }
 
 // ───────────────
@@ -704,10 +705,23 @@ echo '<script type="application/ld+json">' . wp_json_encode( $schema, JSON_UNESC
 
       <div class="tta-event-share">
         <span class="tta-share-label"><?php esc_html_e( 'Share this event', 'tta' ); ?></span>
-        <a href="#" class="tta-share-link" data-platform="facebook">
+        <?php $share_url = get_permalink( $page_id ); ?>
+        <a
+          href="#"
+          class="tta-share-link"
+          data-platform="facebook"
+          data-share-url="<?php echo esc_url( $share_url ); ?>"
+          data-share-message="<?php echo esc_attr( $share_message_meta ); ?>"
+        >
           <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/facebook.svg' ); ?>" alt="Facebook">
         </a>
-        <a href="#" class="tta-share-link" data-platform="instagram">
+        <a
+          href="#"
+          class="tta-share-link"
+          data-platform="instagram"
+          data-share-url="<?php echo esc_url( $share_url ); ?>"
+          data-share-message="<?php echo esc_attr( $share_message_meta ); ?>"
+        >
           <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/instagram.svg' ); ?>" alt="Instagram">
         </a>
       </div>


### PR DESCRIPTION
## Summary
- Share event-specific URL, message, and featured image on Facebook via Open Graph tags
- Refine share dialog text to "Check out this upcoming Trying To Adult event" format
- Document updated sharing behaviour

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3a01a6e48320adc9999379bcd349