### PR TITLE
Fix zero-total checkout triggering payment validation

### DIFF
--- a/assets/js/frontend/tta-accept-checkout.js
+++ b/assets/js/frontend/tta-accept-checkout.js
@@ -130,9 +130,12 @@
       var $btn = $form.find('button[name="tta_do_checkout"]');
       var $spin = $form.find('.tta-admin-progress-spinner-svg');
       const amount = (() => {
-        const clean = s => {
-          const n = parseFloat(String(s || '').trim().replace(/[, ]/g, '').replace(/[^\d.]/g, ''));
-          return isNaN(n) ? null : n.toFixed(2);
+        const clean = (s) => {
+          const match = String(s || '')
+            .trim()
+            .replace(/[, ]+/g, '')
+            .match(/-?\d+(?:\.\d+)?/);
+          return match ? parseFloat(match[0]).toFixed(2) : null;
         };
         return (
           clean($('#tta-final-total').text() || $('#tta-final-total').val()) ||
@@ -142,7 +145,9 @@
           '0.00'
         );
       })();
-      var isFree = parseFloat(amount) <= 0;
+
+      var paymentDisabled = $form.find('[name="card_number"]').is(':disabled');
+      var isFree = parseFloat(amount) <= 0 || paymentDisabled;
       $btn.prop('disabled', true);
       $spin.css({ display: 'inline-block', opacity: 0 }).fadeTo(200, 1);
       showMessage(isFree ? 'Submitting order…' : 'Processing payment…');

--- a/docs/AcceptJsTokenization.md
+++ b/docs/AcceptJsTokenization.md
@@ -1,6 +1,6 @@
 # Accept.js Tokenization
 
-The checkout page now uses [Authorize.Net Accept.js](https://developer.authorize.net/api/reference/features/acceptjs.html) to tokenize payment details in the browser before sending them to the server. When the order total is `$0.00`, this tokenization step is skipped and the checkout finalizes immediately without contacting Authorize.Net.
+The checkout page now uses [Authorize.Net Accept.js](https://developer.authorize.net/api/reference/features/acceptjs.html) to tokenize payment details in the browser before sending them to the server. When the order total is `$0.00`, this tokenization step is skipped and the checkout finalizes immediately without contacting Authorize.Net. Detection of a zero-dollar order relies on the first numeric amount displayed and also bypasses tokenization when the card fields are disabled.
 
 ## Assets
 - `Accept.js` is loaded from Authorize.Net's CDN based on the sandbox or live mode.


### PR DESCRIPTION
## Summary
- Parse first numeric total and skip payment when card fields are disabled to bypass Accept.js on free orders
- Document zero-dollar detection and disabled card bypass for Accept.js tokenization

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4999ce3c832081d324b61dd39bb7