### PR TITLE
Add bulk subscription amount updater

### DIFF
--- a/docs/RecurringBilling.md
+++ b/docs/RecurringBilling.md
@@ -31,9 +31,9 @@ membership level and `subscription_status` return to `active`.
 
 ## Bulk Updating Subscription Amounts
 
-Administrators can correct the monthly charge for existing subscriptions in bulk. Under **TTA Settings → API Settings** enter one or more subscription ID numbers (one per line) and click **Update Subscriptions**. For each ID the plugin retrieves the subscription details from Authorize.Net and adjusts the monthly amount when needed:
+Administrators can correct the monthly charge for existing subscriptions in bulk. Under **TTA Settings → API Settings** enter one or more subscription ID numbers (one per line) and click **Update Subscriptions**. For each ID the plugin retrieves the subscription's name, description, and invoice number from Authorize.Net to determine the plan and adjusts the monthly amount when needed:
 
-* **Trying to Adult Standard Membership** plans are set to $10.
+* **Trying to Adult Standard Membership** plans (including legacy "Trying to Adult Basic Membership" subscriptions) are set to $10.
 * **Trying to Adult Premium Membership** plans are set to $17.
 
 Subscriptions with matching amounts are left unchanged. Results of the update are displayed on the settings page.

--- a/docs/RecurringBilling.md
+++ b/docs/RecurringBilling.md
@@ -29,21 +29,12 @@ subscription issue notice with full billing and address fields plus a link to pu
 When new payment information is submitted the plugin attempts to retry the failed charge immediately—on success the stored
 membership level and `subscription_status` return to `active`.
 
-## Converting Past Transactions
+## Bulk Updating Subscription Amounts
 
-Existing one‑time transactions can be turned into recurring subscriptions
-directly from the admin area. Under **TTA Settings → API Settings** enter one or
-more Authorize.Net transaction IDs (one per line) and click **Convert to
-Subscription**. The plugin retrieves the transaction details for each ID,
-creates an Automated Recurring Billing subscription for the same amount and
-stores the returned subscription ID in the matching `tta_members` record based
-on the billing email. The member's `subscription_status` is set to `active` and
-the `membership_level` updated to `basic` or `premium` depending on the charge
-amount. To ensure Authorize.Net associates the correct billing method, the
-subscription request references the payment profile via the
-`customerPaymentProfileId` field.
-Transactions for $10 are tagged as **Trying to Adult Standard Membership** while $17
-charges become **Trying to Adult Premium Membership** so the subscription is
-clearly labeled in Authorize.Net. The results of each conversion are displayed
-on the settings page and written to the debug log.
+Administrators can correct the monthly charge for existing subscriptions in bulk. Under **TTA Settings → API Settings** enter one or more subscription ID numbers (one per line) and click **Update Subscriptions**. For each ID the plugin retrieves the subscription details from Authorize.Net and adjusts the monthly amount when needed:
+
+* **Trying to Adult Standard Membership** plans are set to $10.
+* **Trying to Adult Premium Membership** plans are set to $17.
+
+Subscriptions with matching amounts are left unchanged. Results of the update are displayed on the settings page.
 

--- a/includes/admin/class-settings-admin.php
+++ b/includes/admin/class-settings-admin.php
@@ -101,17 +101,40 @@ class TTA_Settings_Admin {
 
                         $name        = $details['name'] ?? '';
                         $description = $details['description'] ?? '';
+                        $invoice     = $details['invoice_number'] ?? '';
                         $amount      = (float) ( $details['amount'] ?? 0 );
 
                         $target_amount      = 0;
                         $target_name        = '';
                         $target_description = '';
 
-                        if ( TTA_BASIC_SUBSCRIPTION_NAME === $name || false !== stripos( $description, TTA_BASIC_SUBSCRIPTION_NAME ) ) {
+                        $fields       = [ $name, $description, $invoice ];
+                        $basic_names  = [ TTA_BASIC_SUBSCRIPTION_NAME, 'Trying to Adult Basic Membership' ];
+                        $basic_match  = false;
+                        foreach ( $fields as $field ) {
+                            foreach ( $basic_names as $basic ) {
+                                if ( $field && false !== stripos( $field, $basic ) ) {
+                                    $basic_match = true;
+                                    break 2;
+                                }
+                            }
+                        }
+
+                        $premium_match = false;
+                        if ( ! $basic_match ) {
+                            foreach ( $fields as $field ) {
+                                if ( $field && false !== stripos( $field, TTA_PREMIUM_SUBSCRIPTION_NAME ) ) {
+                                    $premium_match = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if ( $basic_match ) {
                             $target_amount      = TTA_BASIC_MEMBERSHIP_PRICE;
                             $target_name        = TTA_BASIC_SUBSCRIPTION_NAME;
                             $target_description = TTA_BASIC_SUBSCRIPTION_DESCRIPTION;
-                        } elseif ( TTA_PREMIUM_SUBSCRIPTION_NAME === $name || false !== stripos( $description, TTA_PREMIUM_SUBSCRIPTION_NAME ) ) {
+                        } elseif ( $premium_match ) {
                             $target_amount      = TTA_PREMIUM_MEMBERSHIP_PRICE;
                             $target_name        = TTA_PREMIUM_SUBSCRIPTION_NAME;
                             $target_description = TTA_PREMIUM_SUBSCRIPTION_DESCRIPTION;

--- a/includes/api/class-authorizenet-api.php
+++ b/includes/api/class-authorizenet-api.php
@@ -799,6 +799,7 @@ public function charge( $amount, $card_number, $exp_date, $card_code, array $bil
             $name      = $sub && method_exists( $sub, 'getName' ) ? $sub->getName() : '';
             $order     = $sub && method_exists( $sub, 'getOrder' ) ? $sub->getOrder() : null;
             $desc      = $order && method_exists( $order, 'getDescription' ) ? $order->getDescription() : '';
+            $invoice   = $order && method_exists( $order, 'getInvoiceNumber' ) ? $order->getInvoiceNumber() : '';
             $profile   = $sub ? $sub->getProfile() : null;
             $pay_prof  = $profile ? $profile->getPaymentProfile() : null;
             $profile_id = $profile && method_exists( $profile, 'getCustomerProfileId' ) ? $profile->getCustomerProfileId() : '';
@@ -829,6 +830,7 @@ public function charge( $amount, $card_number, $exp_date, $card_code, array $bil
                 'amount'             => $amount,
                 'name'               => tta_sanitize_text_field( $name ),
                 'description'        => tta_sanitize_text_field( $desc ),
+                'invoice_number'     => tta_sanitize_text_field( $invoice ),
                 'exp_date'           => $exp,
                 'billing'            => $billing,
                 'profile_id'         => $profile_id,

--- a/includes/api/class-authorizenet-api.php
+++ b/includes/api/class-authorizenet-api.php
@@ -794,20 +794,23 @@ public function charge( $amount, $card_number, $exp_date, $card_code, array $bil
         $this->log_response( 'get_subscription_details', $response );
 
         if ( $response && 'Ok' === $response->getMessages()->getResultCode() ) {
-            $sub      = $response->getSubscription();
-            $status   = $sub && method_exists( $sub, 'getStatus' ) ? strtolower( $sub->getStatus() ) : '';
-            $profile  = $sub ? $sub->getProfile() : null;
-            $pay_prof = $profile ? $profile->getPaymentProfile() : null;
+            $sub       = $response->getSubscription();
+            $status    = $sub && method_exists( $sub, 'getStatus' ) ? strtolower( $sub->getStatus() ) : '';
+            $name      = $sub && method_exists( $sub, 'getName' ) ? $sub->getName() : '';
+            $order     = $sub && method_exists( $sub, 'getOrder' ) ? $sub->getOrder() : null;
+            $desc      = $order && method_exists( $order, 'getDescription' ) ? $order->getDescription() : '';
+            $profile   = $sub ? $sub->getProfile() : null;
+            $pay_prof  = $profile ? $profile->getPaymentProfile() : null;
             $profile_id = $profile && method_exists( $profile, 'getCustomerProfileId' ) ? $profile->getCustomerProfileId() : '';
             $payment_profile_id = $profile && method_exists( $profile, 'getCustomerPaymentProfileId' ) ? $profile->getCustomerPaymentProfileId() : '';
-            $payment  = $pay_prof ? $pay_prof->getPayment() : null;
-            $card     = $payment ? $payment->getCreditCard() : null;
-            $masked   = $card ? $card->getCardNumber() : '';
-            $last4    = preg_match( '/(\d{4})$/', $masked, $m ) ? $m[1] : '';
-            $exp      = $card && method_exists( $card, 'getExpirationDate' ) ? $card->getExpirationDate() : '';
-            $amount   = $sub && method_exists( $sub, 'getAmount' ) ? floatval( $sub->getAmount() ) : 0.0;
-            $bill     = $pay_prof && method_exists( $pay_prof, 'getBillTo' ) ? $pay_prof->getBillTo() : null;
-            $billing  = [];
+            $payment   = $pay_prof ? $pay_prof->getPayment() : null;
+            $card      = $payment ? $payment->getCreditCard() : null;
+            $masked    = $card ? $card->getCardNumber() : '';
+            $last4     = preg_match( '/(\d{4})$/', $masked, $m ) ? $m[1] : '';
+            $exp       = $card && method_exists( $card, 'getExpirationDate' ) ? $card->getExpirationDate() : '';
+            $amount    = $sub && method_exists( $sub, 'getAmount' ) ? floatval( $sub->getAmount() ) : 0.0;
+            $bill      = $pay_prof && method_exists( $pay_prof, 'getBillTo' ) ? $pay_prof->getBillTo() : null;
+            $billing   = [];
             if ( $bill ) {
                 $billing = [
                     'first_name' => $bill->getFirstName(),
@@ -824,6 +827,8 @@ public function charge( $amount, $card_number, $exp_date, $card_code, array $bil
                 'card_last4'         => $last4,
                 'status'             => $status,
                 'amount'             => $amount,
+                'name'               => tta_sanitize_text_field( $name ),
+                'description'        => tta_sanitize_text_field( $desc ),
                 'exp_date'           => $exp,
                 'billing'            => $billing,
                 'profile_id'         => $profile_id,


### PR DESCRIPTION
## Summary
- repurpose API Settings tool to bulk update Authorize.Net subscription amounts
- expose subscription name/description in API helper for type detection
- document new bulk update workflow

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c81ab4ef2883209f1f75b12420589a