### PR TITLE
Add login/register page template and refresh cart pricing on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Most development work happens inside the plugin located at:
 
 `app/public/wp-content/plugins/tta-management-plugin`
 
-Current plugin version: **1.0.4**
+Current plugin version: **1.0.5**
 
 - Unless a task explicitly states otherwise, assume questions and changes refer to this plugin.
 - The plugin must remain self-contained so it can be copied to another WordPress installation and function on its own.

--- a/assets/css/frontend/event-page.css
+++ b/assets/css/frontend/event-page.css
@@ -315,7 +315,6 @@
 }
 
 .tta-login-accordion .tta-accordion-content.expanded {
-  max-height: 400px;
   padding: 20px 0 0;
   background: #faf8e5;
 }
@@ -762,9 +761,13 @@ input[disabled]::before {
 /* Accordion fade + transition already in place from your description section */
 
 
-#tta-register-form > p{
-  display:inline-block;
-  margin-right: 10px;
+#tta-register-form > p {
+  margin-right: 0;
+  width: 100%;
+}
+
+#tta-register-form > p input {
+  width: 100%;
 }
 
 .tta-event-main #tta-login-message #loginform .login-username, .tta-event-main #tta-login-message #loginform .login-password{

--- a/assets/css/frontend/login-register.css
+++ b/assets/css/frontend/login-register.css
@@ -29,12 +29,15 @@
 }
 
 .tta-section-title {
-  font-size: 1.75rem;
+  font-family: "Teko", sans-serif;
+  font-size: 30px;
+  font-weight: 600;
+  color: #3a7096;
   margin: 0 0 10px;
 }
 
 .tta-section-intro {
-  font-size: 1rem;
+  font-size: 18px;
   margin: 0 0 25px;
   color: #4a4a4a;
 }
@@ -57,7 +60,7 @@
   border: 1px solid #d1d1d1;
   border-radius: 6px;
   padding: 12px;
-  font-size: 1rem;
+  font-size: 14px;
   width: 100%;
 }
 
@@ -100,16 +103,12 @@
   font-weight: 600;
 }
 
-.tta-register-form p {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-bottom: 18px;
-}
-
 .tta-register-form label {
+  display: block;
   font-weight: 600;
   color: #222222;
+  margin-bottom: 6px;
+  font-size: 16px;
 }
 
 .tta-register-form input[type="text"],
@@ -118,7 +117,81 @@
   border: 1px solid #d1d1d1;
   border-radius: 6px;
   padding: 12px;
-  font-size: 1rem;
+  font-size: 14px;
+  width: 100%;
+}
+
+#tta-register-form p:not(.tta-register-actions) {
+  display: inline-block;
+  width: calc(50% - 6px);
+  margin: 0 6px 18px 0;
+  vertical-align: top;
+}
+
+#tta-register-form p:not(.tta-register-actions):nth-of-type(2n) {
+  margin-right: 0;
+}
+
+.tta-password-input {
+  position: relative;
+  display: block;
+}
+
+.tta-password-input input[type="password"],
+.tta-password-input input[type="text"] {
+  width: 100%;
+  padding-right: 48px;
+}
+
+.tta-password-toggle {
+  position: absolute;
+  top: 50%;
+  right: 12px;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  color: #3a7096;
+  cursor: pointer;
+  padding: 0;
+}
+
+.tta-password-toggle:focus,
+.tta-password-toggle:hover {
+  color: #ff6b3d;
+}
+
+.tta-password-toggle-icon {
+  width: 24px;
+  height: 24px;
+}
+
+.tta-password-toggle-icon--hide {
+  display: none;
+}
+
+.tta-password-toggle[aria-pressed="true"] .tta-password-toggle-icon--show {
+  display: none;
+}
+
+.tta-password-toggle[aria-pressed="true"] .tta-password-toggle-icon--hide {
+  display: block;
+}
+
+.tta-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .tta-register-actions {
@@ -126,6 +199,8 @@
   align-items: center;
   gap: 12px;
   margin-top: 10px;
+  width: 100%;
+  margin-right: 0;
 }
 
 .tta-register-actions .tta-button {
@@ -150,6 +225,19 @@
 
 #tta-register-response.error {
   color: #cc0000;
+}
+
+@media (max-width: 1050px) {
+  #tta-register-form p:not(.tta-register-actions) {
+    width: 100%;
+    margin-right: 0;
+  }
+
+  .tta-register-form input[type="text"],
+  .tta-register-form input[type="email"],
+  .tta-register-form input[type="password"] {
+    width: 100%;
+  }
 }
 
 @media (max-width: 767px) {

--- a/assets/css/frontend/login-register.css
+++ b/assets/css/frontend/login-register.css
@@ -1,0 +1,169 @@
+.tta-account-access {
+  padding: 40px 20px 60px;
+  background: #f8f8f8;
+}
+
+.tta-account-access-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.tta-login-register-grid {
+  display: grid;
+  gap: 40px;
+}
+
+@media (min-width: 768px) {
+  .tta-login-register-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: flex-start;
+  }
+}
+
+.tta-login-column,
+.tta-register-column {
+  background: #ffffff;
+  border-radius: 10px;
+  padding: 30px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.05);
+}
+
+.tta-section-title {
+  font-size: 1.75rem;
+  margin: 0 0 10px;
+}
+
+.tta-section-intro {
+  font-size: 1rem;
+  margin: 0 0 25px;
+  color: #4a4a4a;
+}
+
+.tta-login-form #loginform p {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 18px;
+}
+
+.tta-login-form #loginform label {
+  font-weight: 600;
+  color: #222222;
+}
+
+.tta-login-form #loginform input[type="text"],
+.tta-login-form #loginform input[type="password"],
+.tta-login-form #loginform input[type="email"] {
+  border: 1px solid #d1d1d1;
+  border-radius: 6px;
+  padding: 12px;
+  font-size: 1rem;
+  width: 100%;
+}
+
+.tta-login-form #loginform .forgetmenot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.tta-login-form #loginform .forgetmenot label {
+  font-weight: 500;
+  color: #333333;
+}
+
+.tta-login-form #loginform .submit input[type="submit"] {
+  width: 100%;
+  background: #ff6b3d;
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  padding: 14px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.tta-login-form #loginform .submit input[type="submit"]:hover,
+.tta-login-form #loginform .submit input[type="submit"]:focus {
+  background: #e55a2c;
+}
+
+.tta-login-help {
+  margin: 15px 0 0;
+}
+
+.tta-login-help a {
+  color: #0073aa;
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+.tta-register-form p {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 18px;
+}
+
+.tta-register-form label {
+  font-weight: 600;
+  color: #222222;
+}
+
+.tta-register-form input[type="text"],
+.tta-register-form input[type="email"],
+.tta-register-form input[type="password"] {
+  border: 1px solid #d1d1d1;
+  border-radius: 6px;
+  padding: 12px;
+  font-size: 1rem;
+}
+
+.tta-register-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 10px;
+}
+
+.tta-register-actions .tta-button {
+  min-width: 180px;
+}
+
+.tta-register-form .tta-admin-progress-spinner-svg {
+  width: 26px;
+  height: 26px;
+  display: none;
+}
+
+#tta-register-response {
+  display: block;
+  margin-top: 15px;
+  min-height: 22px;
+}
+
+#tta-register-response.updated {
+  color: #0a8754;
+}
+
+#tta-register-response.error {
+  color: #cc0000;
+}
+
+@media (max-width: 767px) {
+  .tta-login-column,
+  .tta-register-column {
+    padding: 24px;
+  }
+
+  .tta-register-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .tta-register-actions .tta-button {
+    width: 100%;
+  }
+}

--- a/assets/css/frontend/login-register.css
+++ b/assets/css/frontend/login-register.css
@@ -1,5 +1,5 @@
 .tta-account-access {
-  padding: 40px 20px 60px;
+  padding: 100px 20px 60px;
   background: #f8f8f8;
 }
 

--- a/assets/css/frontend/login-register.css
+++ b/assets/css/frontend/login-register.css
@@ -42,6 +42,11 @@
   color: #4a4a4a;
 }
 
+.tta-section-intro a.tta-join-link {
+  color: #3a7096;
+  font-weight: 700;
+}
+
 .tta-login-form #loginform p {
   display: flex;
   flex-direction: column;

--- a/assets/css/frontend/style.css
+++ b/assets/css/frontend/style.css
@@ -289,8 +289,9 @@
 
 /* Top bar logout link */
 .tta-header-logout-div {
-  display: none;
-}
-.logged-in .tta-header-logout-div {
   display: inline-block;
+}
+
+body:not(.logged-in) .tta-header-logout-div span {
+  display: none;
 }

--- a/assets/css/frontend/style.css
+++ b/assets/css/frontend/style.css
@@ -292,6 +292,3 @@
   display: inline-block;
 }
 
-body:not(.logged-in) .tta-header-logout-div span {
-  display: none;
-}

--- a/assets/css/frontend/wp-login.css
+++ b/assets/css/frontend/wp-login.css
@@ -1,0 +1,42 @@
+/*
+ * Custom branding for the WordPress core login, password reset, and error pages.
+ */
+.login h1 a {
+  background-image: url(/wp-content/uploads/2022/12/TTA2_Full-1.png);
+  background-image: none, url(/wp-content/uploads/2022/12/TTA2_Full-1.png);
+  background-size: 155px;
+  background-position: center top;
+  background-repeat: no-repeat;
+  color: #3c434a;
+  height: 160px;
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 1.3;
+  margin: 0 auto 24px;
+  padding: 0;
+  text-decoration: none;
+  width: 160px;
+  text-indent: -9999px;
+  outline: 0;
+  overflow: hidden;
+  display: block;
+}
+
+.login #login_error,
+.login .notice,
+.login .notice-error,
+.login .message,
+.login .success {
+  border-left-color: #3a7096;
+}
+
+.login .notice-error,
+.login #login_error {
+  box-shadow: 0 1px 1px 0 rgba(58, 112, 150, 0.15);
+}
+
+.login .message,
+.login .notice,
+.login .success {
+  border-left: 4px solid #3a7096;
+}

--- a/assets/js/frontend/login-register-page.js
+++ b/assets/js/frontend/login-register-page.js
@@ -1,0 +1,87 @@
+(function ($) {
+  'use strict';
+
+  $(function () {
+    var settings = window.ttaLoginRegister || {};
+    var $form = $('#tta-register-form');
+    if (!$form.length) {
+      return;
+    }
+
+    var $spinner = $form.find('.tta-admin-progress-spinner-svg');
+    var $button = $form.find('button[type="submit"]');
+    var $response = $('#tta-register-response');
+
+    $spinner.hide();
+
+    function resetState() {
+      $response.removeClass('error updated').text('');
+    }
+
+    function showError(message) {
+      $response.removeClass('updated').addClass('error').text(message);
+    }
+
+    function showSuccess(message) {
+      $response.removeClass('error').addClass('updated').text(message);
+    }
+
+    $form.on('submit', function (event) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      resetState();
+
+      var email = $form.find('[name="email"]').val();
+      var emailVerify = $form.find('[name="email_verify"]').val();
+      var password = $form.find('[name="password"]').val();
+      var passwordVerify = $form.find('[name="password_verify"]').val();
+
+      if (email !== emailVerify) {
+        showError(settings.emailMismatch || 'Email addresses do not match.');
+        return;
+      }
+
+      if (password !== passwordVerify) {
+        showError(settings.passwordMismatch || 'Passwords do not match.');
+        return;
+      }
+
+      if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/.test(password)) {
+        showError(settings.passwordRequirements || 'Password requirements not met.');
+        return;
+      }
+
+      $button.prop('disabled', true);
+      $spinner.show().css({ opacity: 0 }).fadeTo(200, 1);
+
+      $.post(settings.ajaxUrl, {
+        action: 'tta_register',
+        nonce: settings.nonce,
+        first_name: $form.find('[name="first_name"]').val(),
+        last_name: $form.find('[name="last_name"]').val(),
+        email: email,
+        email_verify: emailVerify,
+        password: password,
+        password_verify: passwordVerify
+      }, null, 'json').done(function (response) {
+        $spinner.fadeOut(200);
+        if (response && response.success) {
+          showSuccess(settings.successMessage || 'Account created! Redirecting…');
+          var redirectUrl = settings.redirectUrl || window.location.href;
+          setTimeout(function () {
+            window.location.href = redirectUrl;
+          }, 600);
+        } else {
+          $button.prop('disabled', false);
+          var msg = response && response.data && response.data.message ? response.data.message : (settings.requestFailed || 'Request failed.');
+          showError(msg);
+        }
+      }).fail(function () {
+        $spinner.fadeOut(200);
+        $button.prop('disabled', false);
+        showError(settings.requestFailed || 'Request failed.');
+      });
+    });
+  });
+})(jQuery);

--- a/assets/js/frontend/login-register-page.js
+++ b/assets/js/frontend/login-register-page.js
@@ -11,12 +11,39 @@
     var $spinner = $form.find('.tta-admin-progress-spinner-svg');
     var $button = $form.find('button[type="submit"]');
     var $response = $('#tta-register-response');
+    var showPasswordText = settings.showPassword || 'Show password';
+    var hidePasswordText = settings.hidePassword || 'Hide password';
 
     $spinner.hide();
 
     function resetState() {
       $response.removeClass('error updated').text('');
     }
+
+    function setToggleState($toggle, isVisible) {
+      $toggle.attr('aria-pressed', isVisible);
+      $toggle.find('.tta-visually-hidden').text(isVisible ? hidePasswordText : showPasswordText);
+    }
+
+    $form.find('.tta-password-toggle').each(function () {
+      setToggleState($(this), false);
+    });
+
+    $form.on('click', '.tta-password-toggle', function (event) {
+      event.preventDefault();
+
+      var $toggle = $(this);
+      var targetId = $toggle.attr('data-target');
+      var $input = targetId ? $('#' + targetId) : $toggle.closest('.tta-password-input').find('input').first();
+
+      if (!$input.length) {
+        return;
+      }
+
+      var makeVisible = $input.attr('type') === 'password';
+      $input.attr('type', makeVisible ? 'text' : 'password');
+      setToggleState($toggle, makeVisible);
+    });
 
     function showError(message) {
       $response.removeClass('updated').addClass('error').text(message);

--- a/assets/js/frontend/logout.js
+++ b/assets/js/frontend/logout.js
@@ -1,15 +1,36 @@
 /**
  * Handle top bar logout link.
  */
-document.addEventListener('DOMContentLoaded', function () {
-    if ( typeof TTALogout === 'undefined' ) {
-        return;
-    }
-    var link = document.querySelector('.tta-header-logout-div a');
-    if ( link ) {
-        link.setAttribute('href', TTALogout.url);
-        if ( TTALogout.name ) {
-            link.innerHTML = link.innerHTML.replace('[USER FIRST NAME]', TTALogout.name);
+(function () {
+    function updateLogoutLink() {
+        if ( typeof TTALogout === 'undefined' ) {
+            return;
+        }
+
+        var container = document.querySelector('.tta-header-logout-div');
+        if ( ! container ) {
+            return;
+        }
+
+        var link = container.querySelector('a');
+        if ( ! link ) {
+            return;
+        }
+
+        if ( TTALogout.loggedIn ) {
+            link.setAttribute('href', TTALogout.url);
+            if ( TTALogout.name ) {
+                link.innerHTML = link.innerHTML.replace('[USER FIRST NAME]', TTALogout.name);
+            }
+        } else {
+            link.setAttribute('href', TTALogout.loginUrl);
+            link.textContent = TTALogout.loginLabel || 'Login';
         }
     }
-});
+
+    if ( document.readyState === 'loading' ) {
+        document.addEventListener('DOMContentLoaded', updateLogoutLink);
+    } else {
+        updateLogoutLink();
+    }
+})();

--- a/assets/js/frontend/logout.js
+++ b/assets/js/frontend/logout.js
@@ -24,7 +24,7 @@
             }
         } else {
             link.setAttribute('href', TTALogout.loginUrl);
-            link.textContent = TTALogout.loginLabel || 'Login';
+            link.textContent = TTALogout.loginLabel || 'Log In';
         }
     }
 

--- a/docs/LoginRegisterPage.md
+++ b/docs/LoginRegisterPage.md
@@ -24,6 +24,10 @@ screen.
   validation rules used across the site (matching email/password pairs and
   strong password requirements). Registration happens via the existing
   `tta_register` AJAX endpoint.
+- **Password visibility toggles** on both registration password fields so
+  visitors can confirm their entries on desktop and mobile. The toggle keeps
+  the control accessible by announcing its current state via screen reader
+  text.
 - **Automatic redirect** to the Events Listings page after either a
   successful login or a successful account creation. The redirect
   destination can be changed with the

--- a/docs/LoginRegisterPage.md
+++ b/docs/LoginRegisterPage.md
@@ -1,0 +1,65 @@
+# Login or Create Account Page
+
+## Overview
+The **Login or Create Account Page** template provides a dedicated landing
+page where visitors can either log in with their existing WordPress account
+or register for a new Trying To Adult account. The template is located at
+`includes/frontend/templates/login-register-page-template.php` and can be
+assigned to any WordPress page via the **Page Attributes → Template**
+dropdown in the editor.
+
+When the template is active the plugin enqueues a lightweight stylesheet
+(`assets/css/frontend/login-register.css`) that presents the login and
+registration forms in a responsive two-column layout (stacking on mobile),
+as well as a small JavaScript controller
+(`assets/js/frontend/login-register-page.js`) that drives the registration
+flow.
+
+## Features
+- **WordPress login form** on the left-hand column. Users are redirected to
+  the Events Listings page (`/events`) after a successful login. A “Forgot
+your password?” link points to the standard WordPress password reset
+screen.
+- **Custom registration form** on the right-hand column that mirrors the
+  validation rules used across the site (matching email/password pairs and
+  strong password requirements). Registration happens via the existing
+  `tta_register` AJAX endpoint.
+- **Automatic redirect** to the Events Listings page after either a
+  successful login or a successful account creation. The redirect
+  destination can be changed with the
+  `tta_login_register_redirect_url` filter if required.
+- **Cart refresh on login** – as soon as a visitor logs in (either through
+  the embedded form or elsewhere) the helper
+  `tta_refresh_cart_session_for_user()` recalculates any cart items stored in
+their current session so the prices reflect the user’s membership level.
+  Existing cart contents are preserved, but cached notices and stale
+  checkout keys are cleared to prevent mismatched pricing.
+
+## Registration Flow
+1. Users fill in the registration form and submit it.
+2. `assets/js/frontend/login-register-page.js` validates the input client-
+   side and posts the data to the `tta_register` AJAX handler.
+3. Upon success the handler creates the WordPress user, logs them in, and
+   triggers the `wp_login` action so the cart refresh runs immediately.
+4. The browser redirects to `/events` (or the filtered URL) after displaying
+   a brief success message.
+
+Any registration errors are surfaced inline by the script, using the same
+localized strings as other registration experiences within the plugin.
+
+## Styling Notes
+- The CSS targets the `.tta-account-access` wrapper so the styles apply only
+  to this template.
+- The spinner image (`assets/images/admin/loading.svg`) is reused from other
+  admin-style progress indicators and is hidden by default until the form is
+  submitting.
+
+## Related Helpers
+- `tta_refresh_cart_session_for_user( $user_id )` – recalculates the active
+  cart session pricing based on the logged-in user’s membership level while
+  preserving cart contents.
+- `tta_login_redirect` – now respects the requested redirect URL when one is
+  supplied, allowing the login form to send users directly to `/events`.
+
+These helpers live in `includes/helpers.php` and are shared across any login
+flow inside the plugin.

--- a/docs/TopBarLogout.md
+++ b/docs/TopBarLogout.md
@@ -10,7 +10,7 @@ The theme's top bar markup may include an empty logout container:
 
 This plugin automatically handles that element:
 
-- Visitors who are not logged in see a “Login” link that points to the
+- Visitors who are not logged in see a “Log In” link that points to the
   `/login-or-create-an-account/` page.
 - When a member is logged in, the plugin sets the anchor's `href` to a secure
   logout URL that redirects back to the site's homepage.

--- a/docs/TopBarLogout.md
+++ b/docs/TopBarLogout.md
@@ -10,11 +10,14 @@ The theme's top bar markup may include an empty logout container:
 
 This plugin automatically handles that element:
 
-- The entire `.tta-header-logout-div` is hidden for visitors who are not logged in.
+- Visitors who are not logged in see a “Login” link that points to the
+  `/login-or-create-an-account/` page.
 - When a member is logged in, the plugin sets the anchor's `href` to a secure
   logout URL that redirects back to the site's homepage.
 - If the link contains the placeholder `[USER FIRST NAME]`, it will be replaced
-  with the logged-in member's first name.
+  with the logged-in member's first name. Any separator spans that surround the
+  placeholder are automatically hidden when the login link is shown, so the
+  markup can stay exactly as in the example above.
 
 No additional configuration is required—simply keep the markup as shown above
 in the theme or Customizer and the plugin will manage visibility and logout

--- a/docs/WPLoginBranding.md
+++ b/docs/WPLoginBranding.md
@@ -1,0 +1,11 @@
+# WordPress Login Branding
+
+The plugin customizes the core WordPress login, password reset, and error screens so the experience matches the Trying To Adult RVA brand.
+
+## What is customized?
+
+- **Logo:** Replaces the default WordPress mark with the Trying To Adult RVA logo located at `/wp-content/uploads/2022/12/TTA2_Full-1.png`.
+- **Alert colors:** Aligns error, message, and success notices with the primary brand color `#3a7096` while leaving password strength indicators unchanged.
+- **Password reset email:** Sends a friendlier message with a subject of `Reset Your {Site Name} Password!` and clear instructions containing the reset link.
+
+All styling overrides are isolated in `assets/css/frontend/wp-login.css` and loaded through `TTA_Login_Branding` (see `includes/login/class-tta-login-branding.php`). Email copy changes use standard WordPress filters so the functionality remains portable across environments.

--- a/includes/admin/views/events-create.php
+++ b/includes/admin/views/events-create.php
@@ -241,6 +241,20 @@ $volunteers = ! empty( $event['volunteers'] ) ? tta_get_member_names_by_ids( exp
             </td>
         </tr>
 
+        <!-- Venue Name -->
+        <tr>
+            <th>
+                <span class="tta-tooltip-icon" data-tooltip="<?php echo esc_attr( TTA_Tooltips::get( TTA_Tooltips::VENUE_NAME ) ); ?>">
+                    <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
+                </span>
+                <label for="venuename">Venue Name</label>
+            </th>
+            <td>
+                <input type="text" name="venuename" id="venuename" class="regular-text" list="tta-venue-options" required
+                       value="<?php echo esc_attr( $event['venuename'] ?? '' ); ?>">
+            </td>
+        </tr>
+
         <!-- Street Address -->
         <tr>
             <th>
@@ -327,20 +341,6 @@ $volunteers = ! empty( $event['volunteers'] ) ? tta_get_member_names_by_ids( exp
             <td>
                 <input type="text" name="zip" id="zip" class="regular-text"
                        value="<?php echo esc_attr( explode(' - ', $event['address'] ?? '')[4] ?? '' ); ?>">
-            </td>
-        </tr>
-
-        <!-- Venue Name -->
-        <tr>
-            <th>
-                <span class="tta-tooltip-icon" data-tooltip="<?php echo esc_attr( TTA_Tooltips::get( TTA_Tooltips::VENUE_NAME ) ); ?>">
-                    <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
-                </span>
-                <label for="venuename">Venue Name</label>
-            </th>
-            <td>
-                <input type="text" name="venuename" id="venuename" class="regular-text" list="tta-venue-options" required
-                       value="<?php echo esc_attr($event['venuename'] ?? ''); ?>">
             </td>
         </tr>
 

--- a/includes/admin/views/events-edit.php
+++ b/includes/admin/views/events-edit.php
@@ -168,6 +168,23 @@ $volunteers = ! empty( $event['volunteers'] ) ? tta_get_member_names_by_ids( exp
                 </td>
             </tr>
 
+            <!-- Venue Name -->
+            <tr>
+                <th>
+                    <span class="tta-tooltip-icon"
+                          data-tooltip="<?php echo esc_attr( TTA_Tooltips::get( TTA_Tooltips::VENUE_NAME ) ); ?>"
+                          style="margin-left:4px;">
+                        <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
+                             alt="Help">
+                    </span>
+                    <label for="venuename">Venue Name</label>
+                </th>
+                <td>
+                    <input type="text" name="venuename" id="venuename" class="regular-text" list="tta-venue-options"
+                           value="<?php echo esc_attr( $event['venuename'] ?? '' ); ?>">
+                </td>
+            </tr>
+
             <?php
             // Split address into pieces
             $parts = isset( $event['address'] ) ? explode( ' - ', $event['address'] ) : [];
@@ -275,23 +292,6 @@ $volunteers = ! empty( $event['volunteers'] ) ? tta_get_member_names_by_ids( exp
                 <td>
                     <input type="text" name="zip" id="zip" class="regular-text"
                            value="<?php echo esc_attr( $zip ); ?>">
-                </td>
-            </tr>
-
-            <!-- Venue Name -->
-            <tr>
-                <th>
-                    <span class="tta-tooltip-icon"
-                          data-tooltip="<?php echo esc_attr( TTA_Tooltips::get( TTA_Tooltips::VENUE_NAME ) ); ?>"
-                          style="margin-left:4px;">
-                        <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
-                             alt="Help">
-                    </span>
-                    <label for="venuename">Venue Name</label>
-                </th>
-                <td>
-                    <input type="text" name="venuename" id="venuename" class="regular-text" list="tta-venue-options"
-                           value="<?php echo esc_attr( $event['venuename'] ?? '' ); ?>">
                 </td>
             </tr>
 

--- a/includes/ajax/handlers/class-ajax-auth.php
+++ b/includes/ajax/handlers/class-ajax-auth.php
@@ -90,6 +90,12 @@ class TTA_Ajax_Auth {
 
         wp_set_current_user( $uid );
         wp_set_auth_cookie( $uid, true );
+
+        $user_obj = get_user_by( 'id', $uid );
+        if ( $user_obj ) {
+            do_action( 'wp_login', $user_obj->user_login, $user_obj );
+        }
+
         TTA_Cache::flush();
 
         wp_send_json_success();

--- a/includes/classes/class-tta-assets.php
+++ b/includes/classes/class-tta-assets.php
@@ -199,8 +199,11 @@ class TTA_Assets {
             'tta-logout-link',
             'TTALogout',
             [
-                'url'  => wp_logout_url( home_url( '/' ) ),
-                'name' => $first_name,
+                'url'        => wp_logout_url( home_url( '/' ) ),
+                'name'       => $first_name,
+                'loggedIn'   => is_user_logged_in(),
+                'loginUrl'   => home_url( '/login-or-create-an-account/' ),
+                'loginLabel' => esc_html__( 'Login', 'tta-management-plugin' ),
             ]
         );
 

--- a/includes/classes/class-tta-assets.php
+++ b/includes/classes/class-tta-assets.php
@@ -568,6 +568,41 @@ class TTA_Assets {
             );
         }
 
+        // Login/Register page template assets
+        if ( function_exists( 'is_page_template' ) && is_page_template( 'login-register-page-template.php' ) ) {
+            wp_enqueue_style(
+                'tta-login-register-css',
+                TTA_PLUGIN_URL . 'assets/css/frontend/login-register.css',
+                [ 'tta-frontend-css' ],
+                TTA_PLUGIN_VERSION
+            );
+
+            wp_enqueue_script(
+                'tta-login-register-js',
+                TTA_PLUGIN_URL . 'assets/js/frontend/login-register-page.js',
+                [ 'jquery' ],
+                TTA_PLUGIN_VERSION,
+                true
+            );
+
+            $redirect_url = apply_filters( 'tta_login_register_redirect_url', home_url( '/events' ) );
+
+            wp_localize_script(
+                'tta-login-register-js',
+                'ttaLoginRegister',
+                [
+                    'ajaxUrl'              => admin_url( 'admin-ajax.php' ),
+                    'nonce'                => wp_create_nonce( 'tta_frontend_nonce' ),
+                    'redirectUrl'          => esc_url_raw( $redirect_url ),
+                    'emailMismatch'        => __( 'Email addresses do not match.', 'tta' ),
+                    'passwordMismatch'     => __( 'Passwords do not match.', 'tta' ),
+                    'passwordRequirements' => __( 'Password must be at least 8 characters and include upper and lower case letters and a number.', 'tta' ),
+                    'requestFailed'        => __( 'Request failed.', 'tta' ),
+                    'successMessage'       => __( 'Account created! Redirecting…', 'tta' ),
+                ]
+            );
+        }
+
         // 5) Host Check-In template assets
         if ( function_exists( 'is_page_template' ) && is_page_template( 'host-checkin-template.php' ) ) {
             wp_enqueue_script(

--- a/includes/classes/class-tta-assets.php
+++ b/includes/classes/class-tta-assets.php
@@ -203,7 +203,7 @@ class TTA_Assets {
                 'name'       => $first_name,
                 'loggedIn'   => is_user_logged_in(),
                 'loginUrl'   => home_url( '/login-or-create-an-account/' ),
-                'loginLabel' => esc_html__( 'Login', 'tta-management-plugin' ),
+                'loginLabel' => esc_html__( 'Log In', 'tta-management-plugin' ),
             ]
         );
 

--- a/includes/classes/class-tta-assets.php
+++ b/includes/classes/class-tta-assets.php
@@ -599,6 +599,8 @@ class TTA_Assets {
                     'passwordRequirements' => __( 'Password must be at least 8 characters and include upper and lower case letters and a number.', 'tta' ),
                     'requestFailed'        => __( 'Request failed.', 'tta' ),
                     'successMessage'       => __( 'Account created! Redirecting…', 'tta' ),
+                    'showPassword'         => __( 'Show password', 'tta' ),
+                    'hidePassword'         => __( 'Hide password', 'tta' ),
                 ]
             );
         }

--- a/includes/frontend/class-login-register-page.php
+++ b/includes/frontend/class-login-register-page.php
@@ -1,0 +1,33 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class TTA_Login_Register_Page {
+    public static function init() {
+        add_filter( 'theme_page_templates', [ __CLASS__, 'register_template' ] );
+        add_filter( 'template_include', [ __CLASS__, 'load_template' ] );
+    }
+
+    public static function register_template( $templates ) {
+        $templates['login-register-page-template.php'] = __( 'Login or Create Account Page', 'tta' );
+        return $templates;
+    }
+
+    public static function load_template( $template ) {
+        if ( is_page() ) {
+            global $post;
+            $tpl = get_post_meta( $post->ID, '_wp_page_template', true );
+            if ( 'login-register-page-template.php' === $tpl ) {
+                $file = plugin_dir_path( __FILE__ ) . 'templates/login-register-page-template.php';
+                if ( file_exists( $file ) ) {
+                    return $file;
+                }
+            }
+        }
+
+        return $template;
+    }
+}
+
+TTA_Login_Register_Page::init();

--- a/includes/frontend/templates/login-register-page-template.php
+++ b/includes/frontend/templates/login-register-page-template.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Template Name: Login or Create Account Page
+ *
+ * Dedicated page template that presents login and registration forms
+ * side-by-side for easy account access.
+ *
+ * @package TTA
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+get_header();
+
+$redirect_url = home_url( '/events' );
+$login_form   = wp_login_form(
+    [
+        'echo'     => false,
+        'redirect' => esc_url_raw( $redirect_url ),
+        'remember' => true,
+    ]
+);
+$lost_pw_url = wp_lostpassword_url( $redirect_url );
+?>
+<div class="tta-account-access">
+  <div class="tta-account-access-inner">
+    <div class="tta-login-register-grid">
+      <section class="tta-login-column">
+        <h1 class="tta-section-title"><?php esc_html_e( 'Already Have an Account? Log In Below!', 'tta' ); ?></h1>
+        <p class="tta-section-intro"><?php esc_html_e( 'Log in to unlock member-only pricing, manage your upcoming events, and access your dashboard.', 'tta' ); ?></p>
+        <div class="tta-login-form">
+          <?php echo $login_form; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+          <p class="tta-login-help"><a href="<?php echo esc_url( $lost_pw_url ); ?>"><?php esc_html_e( 'Forgot your password?', 'tta' ); ?></a></p>
+        </div>
+      </section>
+      <section class="tta-register-column">
+        <h1 class="tta-section-title"><?php esc_html_e( 'Don’t Have an Account? Create One Below!', 'tta' ); ?></h1>
+        <p class="tta-section-intro"><?php esc_html_e( 'Create an account to join events faster, save your preferences, and see pricing tailored to your membership level.', 'tta' ); ?></p>
+        <form id="tta-register-form" class="tta-register-form">
+          <p>
+            <label><?php esc_html_e( 'First Name', 'tta' ); ?><br />
+              <input type="text" name="first_name" autocomplete="given-name" required />
+            </label>
+          </p>
+          <p>
+            <label><?php esc_html_e( 'Last Name', 'tta' ); ?><br />
+              <input type="text" name="last_name" autocomplete="family-name" required />
+            </label>
+          </p>
+          <p>
+            <label><?php esc_html_e( 'Email', 'tta' ); ?><br />
+              <input type="email" name="email" autocomplete="email" required />
+            </label>
+          </p>
+          <p>
+            <label><?php esc_html_e( 'Verify Email', 'tta' ); ?><br />
+              <input type="email" name="email_verify" autocomplete="email" required />
+            </label>
+          </p>
+          <p>
+            <label><?php esc_html_e( 'Password', 'tta' ); ?><br />
+              <input type="password" name="password" autocomplete="new-password" required />
+            </label>
+          </p>
+          <p>
+            <label><?php esc_html_e( 'Verify Password', 'tta' ); ?><br />
+              <input type="password" name="password_verify" autocomplete="new-password" required />
+            </label>
+          </p>
+          <p class="tta-register-actions">
+            <button type="submit" class="tta-button tta-button-primary"><?php esc_html_e( 'Create Account', 'tta' ); ?></button>
+            <img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" />
+          </p>
+          <span id="tta-register-response" class="tta-admin-progress-response-p" role="status" aria-live="polite"></span>
+        </form>
+      </section>
+    </div>
+  </div>
+</div>
+<?php
+get_footer();

--- a/includes/frontend/templates/login-register-page-template.php
+++ b/includes/frontend/templates/login-register-page-template.php
@@ -57,7 +57,23 @@ $lost_pw_url = wp_lostpassword_url( $redirect_url );
       </section>
       <section class="tta-register-column">
         <h1 class="tta-section-title"><?php esc_html_e( 'Don’t Have an Account? Create One Below!', 'tta' ); ?></h1>
-        <p class="tta-section-intro"><?php esc_html_e( 'Create an account to join select events, update your profile info, and sign up for a membership.', 'tta' ); ?></p>
+        <p class="tta-section-intro">
+          <?php
+          printf(
+              wp_kses(
+                  /* translators: %s: Become a Member page URL. */
+                  __( 'Create an account below, and then consider <a class="tta-join-link" href="%s">signing up for a Membership</a> to access member-only events and pricing discounts!', 'tta' ),
+                  [
+                      'a' => [
+                          'href'  => [],
+                          'class' => [],
+                      ],
+                  ]
+              ),
+              esc_url( home_url( '/become-a-member/' ) )
+          );
+          ?>
+        </p>
         <form id="tta-register-form" class="tta-register-form">
           <p>
             <label for="tta-register-first-name"><?php esc_html_e( 'First Name', 'tta' ); ?></label>

--- a/includes/frontend/templates/login-register-page-template.php
+++ b/includes/frontend/templates/login-register-page-template.php
@@ -43,34 +43,58 @@ $lost_pw_url = wp_lostpassword_url( $redirect_url );
         <p class="tta-section-intro"><?php esc_html_e( 'Create an account to join events faster, save your preferences, and see pricing tailored to your membership level.', 'tta' ); ?></p>
         <form id="tta-register-form" class="tta-register-form">
           <p>
-            <label><?php esc_html_e( 'First Name', 'tta' ); ?><br />
-              <input type="text" name="first_name" autocomplete="given-name" required />
-            </label>
+            <label for="tta-register-first-name"><?php esc_html_e( 'First Name', 'tta' ); ?></label>
+            <input id="tta-register-first-name" type="text" name="first_name" autocomplete="given-name" required />
           </p>
           <p>
-            <label><?php esc_html_e( 'Last Name', 'tta' ); ?><br />
-              <input type="text" name="last_name" autocomplete="family-name" required />
-            </label>
+            <label for="tta-register-last-name"><?php esc_html_e( 'Last Name', 'tta' ); ?></label>
+            <input id="tta-register-last-name" type="text" name="last_name" autocomplete="family-name" required />
           </p>
           <p>
-            <label><?php esc_html_e( 'Email', 'tta' ); ?><br />
-              <input type="email" name="email" autocomplete="email" required />
-            </label>
+            <label for="tta-register-email"><?php esc_html_e( 'Email', 'tta' ); ?></label>
+            <input id="tta-register-email" type="email" name="email" autocomplete="email" required />
           </p>
           <p>
-            <label><?php esc_html_e( 'Verify Email', 'tta' ); ?><br />
-              <input type="email" name="email_verify" autocomplete="email" required />
-            </label>
+            <label for="tta-register-email-verify"><?php esc_html_e( 'Verify Email', 'tta' ); ?></label>
+            <input id="tta-register-email-verify" type="email" name="email_verify" autocomplete="email" required />
           </p>
-          <p>
-            <label><?php esc_html_e( 'Password', 'tta' ); ?><br />
-              <input type="password" name="password" autocomplete="new-password" required />
-            </label>
+          <p class="tta-password-field">
+            <label for="tta-register-password"><?php esc_html_e( 'Password', 'tta' ); ?></label>
+            <span class="tta-password-input">
+              <input id="tta-register-password" type="password" name="password" autocomplete="new-password" required />
+              <button type="button" class="tta-password-toggle" data-target="tta-register-password" aria-pressed="false">
+                <span class="tta-visually-hidden"><?php esc_html_e( 'Show password', 'tta' ); ?></span>
+                <svg class="tta-password-toggle-icon tta-password-toggle-icon--show" aria-hidden="true" viewBox="0 0 24 24" focusable="false" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M2 12c2.2-4.5 6.4-7.5 10-7.5s7.8 3 10 7.5c-2.2 4.5-6.4 7.5-10 7.5S4.2 16.5 2 12Z" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                  <circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="1.5" />
+                  <circle cx="12" cy="12" r="1.5" fill="currentColor" />
+                </svg>
+                <svg class="tta-password-toggle-icon tta-password-toggle-icon--hide" aria-hidden="true" viewBox="0 0 24 24" focusable="false" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M2 12c2.2-4.5 6.4-7.5 10-7.5s7.8 3 10 7.5c-2.2 4.5-6.4 7.5-10 7.5S4.2 16.5 2 12Z" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                  <circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="1.5" />
+                  <path d="M4 4l16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </button>
+            </span>
           </p>
-          <p>
-            <label><?php esc_html_e( 'Verify Password', 'tta' ); ?><br />
-              <input type="password" name="password_verify" autocomplete="new-password" required />
-            </label>
+          <p class="tta-password-field">
+            <label for="tta-register-password-verify"><?php esc_html_e( 'Verify Password', 'tta' ); ?></label>
+            <span class="tta-password-input">
+              <input id="tta-register-password-verify" type="password" name="password_verify" autocomplete="new-password" required />
+              <button type="button" class="tta-password-toggle" data-target="tta-register-password-verify" aria-pressed="false">
+                <span class="tta-visually-hidden"><?php esc_html_e( 'Show password', 'tta' ); ?></span>
+                <svg class="tta-password-toggle-icon tta-password-toggle-icon--show" aria-hidden="true" viewBox="0 0 24 24" focusable="false" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M2 12c2.2-4.5 6.4-7.5 10-7.5s7.8 3 10 7.5c-2.2 4.5-6.4 7.5-10 7.5S4.2 16.5 2 12Z" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                  <circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="1.5" />
+                  <circle cx="12" cy="12" r="1.5" fill="currentColor" />
+                </svg>
+                <svg class="tta-password-toggle-icon tta-password-toggle-icon--hide" aria-hidden="true" viewBox="0 0 24 24" focusable="false" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M2 12c2.2-4.5 6.4-7.5 10-7.5s7.8 3 10 7.5c-2.2 4.5-6.4 7.5-10 7.5S4.2 16.5 2 12Z" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                  <circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="1.5" />
+                  <path d="M4 4l16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </button>
+            </span>
           </p>
           <p class="tta-register-actions">
             <button type="submit" class="tta-button tta-button-primary"><?php esc_html_e( 'Create Account', 'tta' ); ?></button>

--- a/includes/frontend/templates/login-register-page-template.php
+++ b/includes/frontend/templates/login-register-page-template.php
@@ -14,6 +14,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 get_header();
 
+$header_shortcode = '[vc_row full_width="stretch_row_content_no_spaces" css=".vc_custom_1670382516702{background-image: url(https://trying-to-adult-rva-2025.local/wp-content/uploads/2022/12/IMG-4418.png?id=70) !important;background-position: center !important;background-repeat: no-repeat !important;background-size: cover !important;}"][vc_column][vc_empty_space height="300px" el_id="jre-header-title-empty"][vc_column_text css_animation="slideInLeft" el_id="jre-homepage-id-1" css=".vc_custom_1671885403487{margin-left: 50px !important;padding-left: 50px !important;}"]<p id="jre-homepage-id-3">LOG IN</p>[/vc_column_text][/vc_column][/vc_row]';
+echo do_shortcode( $header_shortcode );
+
 $redirect_url = home_url( '/events' );
 $login_form   = wp_login_form(
     [

--- a/includes/frontend/templates/login-register-page-template.php
+++ b/includes/frontend/templates/login-register-page-template.php
@@ -32,7 +32,24 @@ $lost_pw_url = wp_lostpassword_url( $redirect_url );
     <div class="tta-login-register-grid">
       <section class="tta-login-column">
         <h1 class="tta-section-title"><?php esc_html_e( 'Already Have an Account? Log In Below!', 'tta' ); ?></h1>
-        <p class="tta-section-intro"><?php esc_html_e( 'Log in to unlock member-only pricing, manage your upcoming events, and access your dashboard.', 'tta' ); ?></p>
+        <p class="tta-section-intro">
+          <?php
+          echo wp_kses(
+              sprintf(
+                  /* translators: %s: Become a Member page URL */
+                  __( 'Log in to see your Standard or Premium Membership pricing on events. Don\'t have a Membership? <a class="tta-join-link" href="%s"><strong>Join Here!</strong></a>', 'tta' ),
+                  esc_url( home_url( '/become-a-member/' ) )
+              ),
+              [
+                  'a'      => [
+                      'href'  => [],
+                      'class' => [],
+                  ],
+                  'strong' => [],
+              ]
+          );
+          ?>
+        </p>
         <div class="tta-login-form">
           <?php echo $login_form; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
           <p class="tta-login-help"><a href="<?php echo esc_url( $lost_pw_url ); ?>"><?php esc_html_e( 'Forgot your password?', 'tta' ); ?></a></p>
@@ -40,7 +57,7 @@ $lost_pw_url = wp_lostpassword_url( $redirect_url );
       </section>
       <section class="tta-register-column">
         <h1 class="tta-section-title"><?php esc_html_e( 'Don’t Have an Account? Create One Below!', 'tta' ); ?></h1>
-        <p class="tta-section-intro"><?php esc_html_e( 'Create an account to join events faster, save your preferences, and see pricing tailored to your membership level.', 'tta' ); ?></p>
+        <p class="tta-section-intro"><?php esc_html_e( 'Create an account to join select events, update your profile info, and sign up for a membership.', 'tta' ); ?></p>
         <form id="tta-register-form" class="tta-register-form">
           <p>
             <label for="tta-register-first-name"><?php esc_html_e( 'First Name', 'tta' ); ?></label>

--- a/includes/frontend/templates/login-register-page-template.php
+++ b/includes/frontend/templates/login-register-page-template.php
@@ -37,7 +37,7 @@ $lost_pw_url = wp_lostpassword_url( $redirect_url );
           echo wp_kses(
               sprintf(
                   /* translators: %s: Become a Member page URL */
-                  __( 'Log in to see your Standard or Premium Membership pricing on events. Don\'t have a Membership? <a class="tta-join-link" href="%s"><strong>Join Here!</strong></a>', 'tta' ),
+                  __( 'Log in to sign up for events, see upcoming events, and check Membership status & perks.  Don\'t have a Membership? <a class="tta-join-link" href="%s"><strong>Join Here!</strong></a>', 'tta' ),
                   esc_url( home_url( '/become-a-member/' ) )
               ),
               [
@@ -62,7 +62,7 @@ $lost_pw_url = wp_lostpassword_url( $redirect_url );
           printf(
               wp_kses(
                   /* translators: %s: Become a Member page URL. */
-                  __( 'Create an account below, and then consider <a class="tta-join-link" href="%s">signing up for a Membership</a> to access member-only events and pricing discounts!', 'tta' ),
+                  __( 'Create a FREE account below.  Sign up for <a class="tta-join-link" href="%s">one of our Memberships</a> to gain access to special perks & discounts.', 'tta' ),
                   [
                       'a' => [
                           'href'  => [],

--- a/includes/login/class-tta-login-branding.php
+++ b/includes/login/class-tta-login-branding.php
@@ -64,6 +64,9 @@ class TTA_Login_Branding {
             __( 'To reset your password, click on the link below:', 'tta' ),
             '',
             $reset_link,
+            '',
+            __( "We're looking forward to seeing you at the next event!", 'tta' ),
+            __( '- The Trying to Adult Team', 'tta' ),
         ];
 
         return implode( "\n", $lines );

--- a/includes/login/class-tta-login-branding.php
+++ b/includes/login/class-tta-login-branding.php
@@ -1,0 +1,73 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class TTA_Login_Branding {
+    /**
+     * Bootstraps the login page branding customizations.
+     */
+    public static function init() {
+        add_action( 'login_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
+        add_filter( 'retrieve_password_title', [ __CLASS__, 'filter_password_reset_title' ], 10, 2 );
+        add_filter( 'retrieve_password_message', [ __CLASS__, 'filter_password_reset_message' ], 10, 4 );
+    }
+
+    /**
+     * Enqueue the branded stylesheet on WordPress core login screens.
+     */
+    public static function enqueue_assets() {
+        wp_enqueue_style(
+            'tta-wp-login',
+            TTA_PLUGIN_URL . 'assets/css/frontend/wp-login.css',
+            [],
+            TTA_PLUGIN_VERSION
+        );
+    }
+
+    /**
+     * Customize the password reset email subject line.
+     *
+     * @param string $title      Default email subject.
+     * @param string $user_login User login name.
+     *
+     * @return string
+     */
+    public static function filter_password_reset_title( $title, $user_login ) {
+        unset( $title, $user_login );
+
+        $blogname = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+
+        return sprintf( __( 'Reset Your %s Password!', 'tta' ), $blogname );
+    }
+
+    /**
+     * Customize the password reset email body copy.
+     *
+     * @param string   $message    Default email message.
+     * @param string   $key        Password reset key.
+     * @param string   $user_login User login name.
+     * @param \WP_User $user_data  User object.
+     *
+     * @return string
+     */
+    public static function filter_password_reset_message( $message, $key, $user_login, $user_data ) {
+        unset( $message, $user_data );
+
+        $reset_link = network_site_url( 'wp-login.php?action=rp&key=' . $key . '&login=' . rawurlencode( $user_login ), 'login' );
+
+        $lines = [
+            __( 'Hi there,', 'tta' ),
+            '',
+            __( "Looks like you need a password reset! If you didn't request this, you can simply ignore this email.", 'tta' ),
+            '',
+            __( 'To reset your password, click on the link below:', 'tta' ),
+            '',
+            $reset_link,
+        ];
+
+        return implode( "\n", $lines );
+    }
+}
+
+TTA_Login_Branding::init();

--- a/trying-to-adult-management-plugin.php
+++ b/trying-to-adult-management-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Trying To Adult Management Plugin
  * Plugin URI: https://example.com
  * Description: Custom plugin for Members, Events, Tickets management with waitlist, notifications, and Authorize.Net integration.
- * Version: 1.0.4
+ * Version: 1.0.5
  * Author: Your Name
  * Author URI: https://example.com
  * Text Domain: trying-to-adult-management
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Define plugin constants
 define( 'TTA_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TTA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-define( 'TTA_PLUGIN_VERSION', '1.0.4' );
+define( 'TTA_PLUGIN_VERSION', '1.0.5' );
 define( 'TTA_DB_VERSION', '1.13.1' );
 define( 'TTA_BASIC_MEMBERSHIP_PRICE', 10.00 );
 define( 'TTA_PREMIUM_MEMBERSHIP_PRICE', 17.00 );
@@ -156,6 +156,7 @@ require_once TTA_PLUGIN_DIR . 'includes/frontend/class-event-page-manager.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-cart-page-manager.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-checkout-page-manager.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-events-list-page.php';
+require_once TTA_PLUGIN_DIR . 'includes/frontend/class-login-register-page.php';
 require_once TTA_PLUGIN_DIR . 'includes/api/class-authorizenet-api.php';
 require_once TTA_PLUGIN_DIR . 'includes/email/class-email-handler.php';
 require_once TTA_PLUGIN_DIR . 'includes/email/class-email-customizer.php';

--- a/trying-to-adult-management-plugin.php
+++ b/trying-to-adult-management-plugin.php
@@ -157,6 +157,7 @@ require_once TTA_PLUGIN_DIR . 'includes/frontend/class-cart-page-manager.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-checkout-page-manager.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-events-list-page.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-login-register-page.php';
+require_once TTA_PLUGIN_DIR . 'includes/login/class-tta-login-branding.php';
 require_once TTA_PLUGIN_DIR . 'includes/api/class-authorizenet-api.php';
 require_once TTA_PLUGIN_DIR . 'includes/email/class-email-handler.php';
 require_once TTA_PLUGIN_DIR . 'includes/email/class-email-customizer.php';


### PR DESCRIPTION
## Summary
- add a dedicated "Login or Create Account" page template with responsive styling and companion documentation
- enqueue template-specific CSS/JS to support AJAX registration, redirect visitors to the events listing, and reuse validation strings
- refresh cart pricing/session data after login or registration so membership discounts are reflected immediately and respect requested login redirects
- bump the plugin version constant and readme reference to 1.0.5

## Testing
- vendor/bin/phpunit *(fails: vendor/bin/phpunit not found in container)*
- php -l includes/helpers.php
- php -l includes/frontend/class-login-register-page.php
- php -l includes/frontend/templates/login-register-page-template.php

------
https://chatgpt.com/codex/tasks/task_e_68c86618366483208c5ba06cec67a2e5