### PR TITLE
Ensure attendee archive migrations avoid duplicates

### DIFF
--- a/includes/classes/class-tta-event-archiver.php
+++ b/includes/classes/class-tta-event-archiver.php
@@ -36,9 +36,15 @@ class TTA_Event_Archiver {
                 }
                 $attendees = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$att_table} WHERE ticket_id = %d", $t['id'] ), ARRAY_A );
                 foreach ( $attendees as $a ) {
-                    $a_exists = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$att_archive} WHERE id = %d", $a['id'] ) );
+                    $att_id   = intval( $a['id'] );
+                    $a_exists = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$att_archive} WHERE id = %d", $att_id ) );
+                    $inserted = true;
                     if ( ! $a_exists ) {
-                        $wpdb->insert( $att_archive, $a );
+                        $inserted = false !== $wpdb->insert( $att_archive, $a );
+                    }
+
+                    if ( $inserted ) {
+                        $wpdb->delete( $att_table, [ 'id' => $att_id ], [ '%d' ] );
                     }
                 }
             }

--- a/tests/AttendeeArchiveRegressionTest.php
+++ b/tests/AttendeeArchiveRegressionTest.php
@@ -1,0 +1,184 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ARRAY_A' ) ) { define( 'ARRAY_A', 'ARRAY_A' ); }
+if ( ! defined( 'ABSPATH' ) ) { define( 'ABSPATH', __DIR__ . '/../' ); }
+if ( ! function_exists( 'sanitize_text_field' ) ) { function sanitize_text_field( $value ) { return is_string( $value ) ? trim( $value ) : $value; } }
+if ( ! function_exists( 'sanitize_email' ) ) { function sanitize_email( $value ) { return is_string( $value ) ? strtolower( trim( $value ) ) : $value; } }
+if ( ! function_exists( 'add_action' ) ) { function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {} }
+if ( ! function_exists( 'add_filter' ) ) { function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {} }
+if ( ! function_exists( 'apply_filters' ) ) { function apply_filters( $hook, $value ) { return $value; } }
+if ( ! function_exists( '__' ) ) { function __( $text ) { return $text; } }
+if ( ! function_exists( 'current_time' ) ) { function current_time( $type ) { return '2024-01-10'; } }
+if ( ! function_exists( 'get_userdata' ) ) { function get_userdata( $id ) { return (object) [ 'user_email' => 'buyer@example.com' ]; } }
+if ( ! function_exists( 'get_permalink' ) ) { function get_permalink( $id ) { return 'https://example.com/page/' . intval( $id ); } }
+if ( ! function_exists( 'wp_json_encode' ) ) { function wp_json_encode( $data ) { return json_encode( $data ); } }
+if ( ! class_exists( 'TTA_Cache' ) ) {
+    class TTA_Cache {
+        public static function get( $key ) { return false; }
+        public static function set( $key, $value, $ttl = 0 ) { return true; }
+        public static function delete( $key ) { return true; }
+        public static function flush() { return true; }
+    }
+}
+
+class AttendeeArchiveRegressionTest extends TestCase {
+    protected function setUp(): void {
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public $attendees;
+            public $attendees_archive;
+            public $transactions;
+            public $history_rows;
+            public $member_id = 77;
+            public function __construct() {
+                $this->attendees = [
+                    [
+                        'id'              => 501,
+                        'ticket_id'       => 101,
+                        'first_name'      => 'Alex',
+                        'last_name'       => 'Doe',
+                        'email'           => 'alex@example.com',
+                        'phone'           => '555-0000',
+                        'status'          => 'no_show',
+                        'transaction_id'  => 99,
+                        'assistance_note' => '',
+                        'opt_in_sms'      => 0,
+                        'created_at'      => '2023-01-01 12:00:00',
+                    ],
+                ];
+                $this->attendees_archive = [
+                    [
+                        'id'              => 501,
+                        'ticket_id'       => 101,
+                        'first_name'      => 'Alex',
+                        'last_name'       => 'Doe',
+                        'email'           => 'alex@example.com',
+                        'phone'           => '555-0000',
+                        'status'          => 'no_show',
+                        'transaction_id'  => 99,
+                        'assistance_note' => '',
+                        'opt_in_sms'      => 0,
+                        'created_at'      => '2023-01-01 12:00:00',
+                    ],
+                ];
+                $this->transactions = [
+                    [
+                        'id'             => 99,
+                        'transaction_id' => 'TX123',
+                        'created_at'     => '2023-01-01 09:00:00',
+                        'wpuserid'       => 123,
+                        'details'        => json_encode([
+                            [
+                                'ticket_id'    => 101,
+                                'event_ute_id' => 'event-ute',
+                                'final_price'  => 25,
+                                'quantity'     => 1,
+                            ],
+                        ]),
+                    ],
+                ];
+                $this->history_rows = [
+                    [
+                        'action_data' => json_encode([
+                            'transaction_id' => 'TX123',
+                            'amount'         => 25,
+                            'items'          => [
+                                [
+                                    'ticket_id' => 101,
+                                    'quantity'  => 1,
+                                    'name'      => 'Ticket',
+                                ],
+                            ],
+                        ]),
+                        'event_id'   => 10,
+                        'name'       => 'Sample Event',
+                        'page_id'    => 44,
+                        'mainimageid'=> 55,
+                        'date'       => '2023-01-01',
+                        'time'       => '10:00',
+                        'address'    => '123 Main St',
+                        'type'       => 'standard',
+                        'refunds'    => 1,
+                    ],
+                ];
+            }
+            public function prepare( $query, ...$args ) {
+                foreach ( $args as $arg ) {
+                    if ( is_array( $arg ) ) {
+                        foreach ( $arg as $sub ) {
+                            $query = preg_replace( '/%s/', $sub, $query, 1 );
+                            $query = preg_replace( '/%d/', (string) (int) $sub, $query, 1 );
+                        }
+                        continue;
+                    }
+                    $query = preg_replace( '/%s/', $arg, $query, 1 );
+                    $query = preg_replace( '/%d/', (string) (int) $arg, $query, 1 );
+                }
+                return $query;
+            }
+            public function get_results( $query, $output = ARRAY_A ) {
+                if ( false !== strpos( $query, 'FROM wp_tta_memberhistory' ) && false !== strpos( $query, "action_type = 'purchase'" ) ) {
+                    return $this->history_rows;
+                }
+                if ( false !== strpos( $query, 'SELECT id, transaction_id FROM wp_tta_transactions WHERE transaction_id IN' ) ) {
+                    return [ [ 'id' => 99, 'transaction_id' => 'TX123' ] ];
+                }
+                if ( false !== strpos( $query, 'SELECT transaction_id, COUNT(*) AS cnt FROM wp_tta_attendees WHERE transaction_id IN' ) ) {
+                    return [ [ 'transaction_id' => 99, 'cnt' => 1 ] ];
+                }
+                if ( false !== strpos( $query, 'SELECT * FROM wp_tta_attendees WHERE ticket_id' ) && false !== strpos( $query, 'wp_tta_attendees_archive' ) ) {
+                    return array_merge( $this->attendees, $this->attendees_archive );
+                }
+                if ( false !== strpos( $query, 'SELECT id, transaction_id, created_at, wpuserid, details FROM wp_tta_transactions WHERE id IN' ) ) {
+                    return $this->transactions;
+                }
+                if ( false !== strpos( $query, 'FROM wp_tta_memberhistory' ) && false !== strpos( $query, "action_type = 'refund'" ) ) {
+                    return [];
+                }
+                if ( false !== strpos( $query, 'FROM wp_tta_attendees_archive WHERE ticket_id' ) ) {
+                    return $this->attendees_archive;
+                }
+                if ( false !== strpos( $query, 'FROM wp_tta_attendees WHERE ticket_id' ) ) {
+                    return $this->attendees;
+                }
+                return [];
+            }
+            public function get_var( $query ) {
+                if ( false !== strpos( $query, 'FROM wp_tta_members WHERE wpuserid' ) ) {
+                    return $this->member_id;
+                }
+                if ( false !== strpos( $query, 'COUNT(*) FROM (' ) && false !== strpos( $query, 'wp_tta_attendees WHERE' ) ) {
+                    $unique = [];
+                    foreach ( $this->attendees as $row ) {
+                        if ( 'no_show' === $row['status'] ) {
+                            $unique[ $row['id'] ] = true;
+                        }
+                    }
+                    foreach ( $this->attendees_archive as $row ) {
+                        if ( 'no_show' === $row['status'] ) {
+                            $unique[ $row['id'] ] = true;
+                        }
+                    }
+                    return count( $unique );
+                }
+                if ( false !== strpos( $query, 'SELECT no_show_offset' ) ) {
+                    return 0;
+                }
+                return 0;
+            }
+        };
+        require_once __DIR__ . '/../includes/helpers.php';
+    }
+
+    public function test_member_history_ignores_duplicate_attendees(): void {
+        $events = tta_get_member_past_events( 123 );
+        $this->assertCount( 1, $events );
+        $this->assertNotEmpty( $events[0]['items'] );
+        $this->assertSame( 1, count( $events[0]['items'][0]['attendees'] ) );
+
+        $count = tta_get_no_show_event_count_by_email( 'alex@example.com' );
+        $this->assertSame( 1, $count );
+    }
+}

--- a/tests/NoShowResetTest.php
+++ b/tests/NoShowResetTest.php
@@ -1,6 +1,8 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
+if (!defined('ABSPATH')) { define('ABSPATH', __DIR__ . '/../'); }
+if (!defined('TTA_PLUGIN_DIR')) { define('TTA_PLUGIN_DIR', __DIR__ . '/../'); }
 if (!defined('ARRAY_A')) { define('ARRAY_A', 'ARRAY_A'); }
 if (!function_exists('sanitize_email')) { function sanitize_email($v){ return is_string($v)?trim($v):$v; } }
 if (!function_exists('sanitize_text_field')) { function sanitize_text_field($v){ return is_string($v)?trim($v):$v; } }
@@ -8,11 +10,28 @@ if (!function_exists('get_userdata')) { function get_userdata($id){ return (obje
 if (!function_exists('get_transient')) { function get_transient($k){ return false; } }
 if (!function_exists('set_transient')) { function set_transient($k,$v,$t){ return true; } }
 if (!function_exists('delete_transient')) { function delete_transient($k){ return true; } }
+if (!function_exists('add_action')) { function add_action($hook,$cb,$prio=10,$args=1){} }
+if (!function_exists('add_filter')) { function add_filter($hook,$cb,$prio=10,$args=1){} }
+if (!function_exists('apply_filters')) { function apply_filters($hook,$value){ return $value; } }
+if (!function_exists('__')) { function __($text){ return $text; } }
+if (!function_exists('get_option')) { function get_option($name,$default=false){ return $default; } }
+if (!function_exists('update_option')) { function update_option($name,$value){ return true; } }
+if (!function_exists('delete_option')) { function delete_option($name){ return true; } }
+if (!function_exists('get_user_by')) { function get_user_by($field,$value){ return (object)['ID'=>0,'user_email'=>'user@example.com','first_name'=>'Test','last_name'=>'User']; } }
+if (!function_exists('esc_url')) { function esc_url($url){ return $url; } }
+if (!function_exists('esc_html')) { function esc_html($text){ return $text; } }
+if (!function_exists('esc_attr')) { function esc_attr($text){ return $text; } }
+if (!function_exists('home_url')) { function home_url($path=''){ return 'https://example.com' . $path; } }
+if (!function_exists('wp_mail')) { function wp_mail($to,$subject,$message,$headers='',$attachments=[]){ return true; } }
+if (!function_exists('wp_next_scheduled')) { function wp_next_scheduled($hook){ return false; } }
+if (!function_exists('wp_schedule_event')) { function wp_schedule_event($time,$recurrence,$hook){ return true; } }
+if (!function_exists('wp_clear_scheduled_hook')) { function wp_clear_scheduled_hook($hook){ return true; } }
 if (!class_exists('TTA_Cache')) {
     class TTA_Cache {
         public static function get($k){ return false; }
         public static function set($k,$v,$t=0){ return true; }
         public static function delete($k){ return true; }
+        public static function remember($key, $ttl, $callback){ return is_callable($callback) ? $callback() : null; }
     }
 }
 if (!defined('TTA_BAN_UNTIL_REENTRY')) { define('TTA_BAN_UNTIL_REENTRY', '9998-12-31 23:59:59'); }
@@ -26,6 +45,9 @@ class NoShowResetTest extends TestCase {
             public $archive = 0;
             public $offset = 5;
             public function get_var($q){
+                if (strpos($q,'COUNT(*) FROM (') !== false && strpos($q,'wp_tta_attendees WHERE') !== false) {
+                    return $this->attendees + $this->archive;
+                }
                 if (strpos($q,'tta_attendees_archive') !== false) return $this->archive;
                 if (strpos($q,'tta_attendees') !== false && strpos($q,'no_show_offset') === false) return $this->attendees;
                 if (strpos($q,'no_show_offset') !== false) return $this->offset;
@@ -47,6 +69,9 @@ class NoShowResetTest extends TestCase {
             public $updated = [];
             public function get_var($q){
                 if (strpos($q,'SELECT status') !== false) return 'pending';
+                if (strpos($q,'COUNT(*) FROM (') !== false && strpos($q,'wp_tta_attendees WHERE') !== false) {
+                    return $this->attendees + $this->archive;
+                }
                 if (strpos($q,'tta_attendees_archive') !== false) return $this->archive;
                 if (strpos($q,'tta_attendees') !== false && strpos($q,'no_show_offset') === false) return $this->attendees;
                 if (strpos($q,'no_show_offset') !== false) return $this->offset;


### PR DESCRIPTION
## Summary
- move attendee rows into the archive when events are archived so the live table stays in sync
- de-duplicate attendee queries and aggregate counts across live and archived tables to prevent double-counting
- add regression coverage for archived attendees and update the existing no-show test scaffolding for the new queries

## Testing
- php -d error_reporting=E_ALL^E_DEPRECATED ./phpunit.phar tests/AttendeeArchiveRegressionTest.php
- php -d error_reporting=E_ALL^E_DEPRECATED ./phpunit.phar tests/NoShowResetTest.php

------
https://chatgpt.com/codex/tasks/task_e_68f567be6b4483208ac5c0ffcb50d4d4