### PR TITLE
Add Authorize.Net gateway diagnostics toggle

### DIFF
--- a/docs/OperatorTestingGuide.md
+++ b/docs/OperatorTestingGuide.md
@@ -7,7 +7,8 @@ This document provides a repeatable process for ChatGPT Operator to validate eve
 1. Ensure the plugin is installed and activated.
 2. Reference [TestingInformation.md](TestingInformation.md) for test account credentials. Each membership level and user role is represented there.
 3. The debug log is available from **TTA Settings → Logging** at `/wp-admin/admin.php?page=tta-settings&tab=logging`.
-4. Do **not** test the `/become-a-member/` page or other links in the site's header or footer.
+4. Authorize.Net diagnostics can be toggled under **TTA Settings → API Settings**. Enable **Gateway Diagnostics** to capture sanitized request/response details and review them in the diagnostics textarea at the bottom of that tab.
+5. Do **not** test the `/become-a-member/` page or other links in the site's header or footer.
 
 ## Testing Checklist
 
@@ -43,6 +44,7 @@ For each of the sample events (`/dinner-at-crawleys/`, `/roller-skating/`, `/buf
 
 ### 5. Logging and Error Handling
 - Review the debug log after each major action. Clear it between scenarios so new entries are easy to spot.
+- When payment issues arise, enable the gateway diagnostics toggle, reproduce the issue, and capture the entries shown in the **Authorize.Net Gateway Diagnostics** textarea before clearing it.
 - Note any warnings or notices that appear and include them in your report.
 
 ## Reporting Results

--- a/includes/classes/class-tta-gateway-diagnostics.php
+++ b/includes/classes/class-tta-gateway-diagnostics.php
@@ -1,0 +1,120 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Store and retrieve Authorize.Net gateway diagnostics.
+ */
+class TTA_Gateway_Diagnostics {
+    const OPTION_ENABLED = 'tta_gateway_logging_enabled';
+    const OPTION_LOG     = 'tta_gateway_diagnostic_log';
+    const MAX_ENTRIES    = 200;
+
+    /**
+     * Check if diagnostics logging is enabled.
+     *
+     * @return bool
+     */
+    public static function is_enabled() {
+        return (bool) get_option( self::OPTION_ENABLED, false );
+    }
+
+    /**
+     * Persist logging state.
+     *
+     * @param bool $enabled Whether logging should be enabled.
+     * @return void
+     */
+    public static function set_enabled( $enabled ) {
+        update_option( self::OPTION_ENABLED, $enabled ? 1 : 0, false );
+    }
+
+    /**
+     * Record a diagnostic entry.
+     *
+     * @param array $entry Diagnostic data to store.
+     * @return void
+     */
+    public static function record( array $entry ) {
+        if ( ! self::is_enabled() ) {
+            return;
+        }
+
+        $entry['timestamp'] = $entry['timestamp'] ?? gmdate( 'Y-m-d H:i:s' );
+        $log                = get_option( self::OPTION_LOG, [] );
+        if ( ! is_array( $log ) ) {
+            $log = [];
+        }
+
+        $log[] = self::sanitize_entry( $entry );
+
+        if ( count( $log ) > self::MAX_ENTRIES ) {
+            $log = array_slice( $log, -self::MAX_ENTRIES );
+        }
+
+        update_option( self::OPTION_LOG, $log, false );
+    }
+
+    /**
+     * Retrieve stored diagnostics.
+     *
+     * @param int $limit Optional number of entries to return.
+     * @return array
+     */
+    public static function get_entries( $limit = 0 ) {
+        $log = get_option( self::OPTION_LOG, [] );
+        if ( ! is_array( $log ) ) {
+            return [];
+        }
+
+        $log = array_values( $log );
+        if ( $limit > 0 ) {
+            $log = array_slice( $log, -absint( $limit ) );
+        }
+
+        return array_reverse( $log );
+    }
+
+    /**
+     * Clear all stored diagnostics.
+     *
+     * @return void
+     */
+    public static function clear() {
+        delete_option( self::OPTION_LOG );
+    }
+
+    /**
+     * Ensure the entry data only contains serializable values.
+     *
+     * @param mixed $value Entry value.
+     * @return mixed
+     */
+    protected static function sanitize_entry( $value ) {
+        if ( is_array( $value ) ) {
+            $clean = [];
+            foreach ( $value as $key => $item ) {
+                $clean[ $key ] = self::sanitize_entry( $item );
+            }
+            return $clean;
+        }
+
+        if ( is_object( $value ) ) {
+            if ( $value instanceof \DateTimeInterface ) {
+                return $value->format( 'c' );
+            }
+            return self::sanitize_entry( json_decode( wp_json_encode( $value ), true ) );
+        }
+
+        if ( is_bool( $value ) ) {
+            return $value;
+        }
+
+        if ( is_scalar( $value ) || null === $value ) {
+            return $value;
+        }
+
+        return (string) maybe_serialize( $value );
+    }
+}

--- a/trying-to-adult-management-plugin.php
+++ b/trying-to-adult-management-plugin.php
@@ -43,6 +43,7 @@ if ( ! defined( 'TTA_AUTHNET_IMPORT_MAX_REQUESTS' ) ) {
 
 require_once TTA_PLUGIN_DIR . 'includes/helpers.php';
 require_once TTA_PLUGIN_DIR . 'includes/classes/class-tta-debug-logger.php';
+require_once TTA_PLUGIN_DIR . 'includes/classes/class-tta-gateway-diagnostics.php';
 TTA_Debug_Logger::init();
 require_once TTA_PLUGIN_DIR . 'includes/classes/class-tta-tooltips.php';
 require_once TTA_PLUGIN_DIR . 'includes/admin-bar.php';


### PR DESCRIPTION
## Summary
- add a stored gateway diagnostics toggle and log store for Authorize.Net requests
- capture sanitized request/response details for charges and subscription workflows when logging is enabled
- expose a diagnostics textarea and clearing action on the API settings tab and document the workflow

## Testing
- php -l includes/api/class-authorizenet-api.php
- php -l includes/admin/class-settings-admin.php
- php -l includes/classes/class-tta-gateway-diagnostics.php

------
https://chatgpt.com/codex/tasks/task_e_6905f3df95548320bad87983b6cb4541