### PR TITLE
Revert reload removal from member dashboard payment updates

### DIFF
--- a/assets/js/frontend/member-dashboard.js
+++ b/assets/js/frontend/member-dashboard.js
@@ -538,6 +538,14 @@ jQuery(function($){
             $('#tta-card-last4').text(data.last4);
           }
           $form[0].reset();
+          if(data.reloadAfter){
+            var wait = parseInt(data.reloadAfter, 10);
+            if(!isNaN(wait) && wait > 0){
+              setTimeout(function(){
+                window.location.reload();
+              }, wait * 1000);
+            }
+          }
         }else{
           var msg = data && data.message ? data.message : 'Error';
           controls.resp.addClass('error').removeClass('updated').text(msg);

--- a/includes/ajax/handlers/class-ajax-membership.php
+++ b/includes/ajax/handlers/class-ajax-membership.php
@@ -197,9 +197,10 @@ class TTA_Ajax_Membership {
         }
 
         wp_send_json_success( [
-            'message' => __( 'Your payment method has been successfully updated. Thanks for being proactive and keeping your membership current!', 'tta' ),
-            'status'  => $status ?: 'active',
-            'last4'   => $last4_form,
+            'message'     => __( 'Your payment method has been successfully updated. Thanks for being proactive and keeping your membership current!', 'tta' ),
+            'status'      => $status ?: 'active',
+            'last4'       => $last4_form,
+            'reloadAfter' => 5,
         ] );
     }
 


### PR DESCRIPTION
## Summary
- revert the change that removed post-payment reloads on the member dashboard
- restore the reloadAfter response field in the membership AJAX handler

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f69096d883208f6e375f28f448ff)