### PR TITLE
Enable token rendering for Twilio test SMS

### DIFF
--- a/includes/admin/class-settings-admin.php
+++ b/includes/admin/class-settings-admin.php
@@ -575,11 +575,29 @@ class TTA_Settings_Admin {
             'subscription_status' => 'active',
         ];
 
+        $refund_attendee = [
+            'first_name' => $primary_first,
+            'last_name'  => $primary_last,
+            'email'      => $primary_email,
+            'phone'      => $primary_phone,
+        ];
+
+        $refund = [
+            'event_id'    => intval( $event['id'] ?? 0 ),
+            'ticket_id'   => 0,
+            'ticket_name' => __( 'Sample Ticket', 'tta' ),
+            'attendee'    => $refund_attendee,
+            'amount'      => 20.00,
+            'first_name'  => $refund_attendee['first_name'],
+            'last_name'   => $refund_attendee['last_name'],
+            'email'       => $refund_attendee['email'],
+        ];
+
         return [
             'event'     => $event,
             'member'    => $member,
             'attendees' => $attendees,
-            'refund'    => [],
+            'refund'    => $refund,
         ];
     }
 

--- a/includes/email/class-email-handler.php
+++ b/includes/email/class-email-handler.php
@@ -180,6 +180,18 @@ class TTA_Email_Handler {
         }
 
         $att_ref = $refund['attendee'] ?? [];
+
+        if ( empty( $att_ref ) && ! empty( $attendees ) ) {
+            $att_ref = $attendees[0];
+        }
+
+        if ( empty( $refund['ticket_name'] ) && ! empty( $refund['ticket_id'] ) && function_exists( 'tta_get_ticket_basic_info' ) ) {
+            $ticket_info = tta_get_ticket_basic_info( intval( $refund['ticket_id'] ) );
+            if ( $ticket_info ) {
+                $refund['ticket_name'] = $ticket_info['ticket_name'];
+            }
+        }
+
         $tokens['{refund_first_name}'] = sanitize_text_field( $refund['first_name'] ?? $att_ref['first_name'] ?? '' );
         $tokens['{refund_last_name}']  = sanitize_text_field( $refund['last_name'] ?? $att_ref['last_name'] ?? '' );
         $tokens['{refund_email}']      = sanitize_email( $refund['email'] ?? $att_ref['email'] ?? '' );


### PR DESCRIPTION
## Summary
- add optional token rendering for Twilio sandbox test SMS using sample preview context
- build sample event, member, and attendee data to compile template tokens
- expose checkbox to control token expansion while keeping freeform messages intact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69302deebb7c8320805ea8b1edeadd7d)