### PR TITLE
Update plugin version to 1.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Most development work happens inside the plugin located at:
 
 `app/public/wp-content/plugins/tta-management-plugin`
 
-Current plugin version: **1.0.7**
+Current plugin version: **1.0.8**
 
 - Unless a task explicitly states otherwise, assume questions and changes refer to this plugin.
 - The plugin must remain self-contained so it can be copied to another WordPress installation and function on its own.

--- a/trying-to-adult-management-plugin.php
+++ b/trying-to-adult-management-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Trying To Adult Management Plugin
  * Plugin URI: https://example.com
  * Description: Custom plugin for Members, Events, Tickets management with waitlist, notifications, and Authorize.Net integration.
- * Version: 1.0.7
+ * Version: 1.0.8
  * Author: Your Name
  * Author URI: https://example.com
  * Text Domain: trying-to-adult-management
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Define plugin constants
 define( 'TTA_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TTA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-define( 'TTA_PLUGIN_VERSION', '1.0.7' );
+define( 'TTA_PLUGIN_VERSION', '1.0.8' );
 define( 'TTA_DB_VERSION', '1.13.1' );
 define( 'TTA_BASIC_MEMBERSHIP_PRICE', 10.00 );
 define( 'TTA_PREMIUM_MEMBERSHIP_PRICE', 17.00 );


### PR DESCRIPTION
## Summary
- bump the plugin header and version constant to 1.0.8
- update the README to reflect the new plugin version

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931f7c7e8388320b9e216306f7025ef)