### PR TITLE
Partner Admin: add 'No Longer Employed' button and AJAX handler

### DIFF
--- a/assets/css/frontend/alert-bar.css
+++ b/assets/css/frontend/alert-bar.css
@@ -79,14 +79,31 @@
 }
 
 .tta-license-panel{
-	padding-left: 10px;
-    margin-bottom: 10px;
+	padding-left: 0;
+	padding-right: 0;
+	margin-bottom: 10px;
+	text-align: center;
+	padding-top: 20px;
+	padding-bottom: 10px;
 }
 
 .tta-license-panel p{
 	display: inline-block;
-    margin-right: 10px;
-    margin-bottom: 0;
+	margin-right: 10px;
+	margin-left: 10px;
+	margin-bottom: 0;
+}
+
+.tta-license-panel strong{
+	display: block;
+}
+
+.tta-license-employment-btn{
+	margin-top: 10px;
+}
+
+.form-table.tta-partner-profile-table td{
+	min-width: 200px;
 }
 
 .tta-license-section.tta-license-summary, .tta-bulk-upload-license-section, .tta-license-single-add, .tta-license-search{

--- a/assets/css/frontend/alert-bar.css
+++ b/assets/css/frontend/alert-bar.css
@@ -102,6 +102,12 @@
 	margin-top: 10px;
 }
 
+.tta-license-single-add .tta-admin-progress-response-p{
+	font-size: 16px;
+	font-weight: normal;
+	margin-top: 10px !important;
+}
+
 .form-table.tta-partner-profile-table td{
 	min-width: 200px;
 }

--- a/assets/css/frontend/alert-bar.css
+++ b/assets/css/frontend/alert-bar.css
@@ -99,7 +99,10 @@
 }
 
 .tta-license-employment-btn{
-	margin-top: 10px;
+	margin-top: 20px;
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
 }
 
 .tta-license-single-add .tta-admin-progress-response-p{

--- a/docs/PartnerAdminPage.md
+++ b/docs/PartnerAdminPage.md
@@ -17,6 +17,9 @@ Page Attributes dropdown.
   Licenses**, which offers a CSV upload (plus downloadable sample) to bulk
   create partner-linked members. Uploaded rows populate first name, last name,
   email, and the partner’s `uniquecompanyidentifier` into `tta_members.partner`.
+- **Member offboarding:** Each member row in the license accordion includes a
+  **No Longer Employed** button that updates the matching `tta_members` record
+  to set `membership_level` to `free` and clears `subscription_status`.
 - **Auto-assignment:** Partner admin pages created via the admin UI are
   automatically set to this template.
 

--- a/docs/PartnerAdminPage.md
+++ b/docs/PartnerAdminPage.md
@@ -19,7 +19,9 @@ Page Attributes dropdown.
   email, and the partner’s `uniquecompanyidentifier` into `tta_members.partner`.
 - **Member offboarding:** Each member row in the license accordion includes a
   **No Longer Employed** button that updates the matching `tta_members` record
-  to set `membership_level` to `free` and clears `subscription_status`.
+  to set `membership_level` to `free`, clears `subscription_status`, and
+  prefixes the `partner` value with `notemployed-` (or `nle-` if the resulting
+  string would exceed the column length).
 - **Auto-assignment:** Partner admin pages created via the admin UI are
   automatically set to this template.
 

--- a/includes/ajax/handlers/class-ajax-partners.php
+++ b/includes/ajax/handlers/class-ajax-partners.php
@@ -468,7 +468,7 @@ class TTA_Ajax_Partners {
 
         wp_send_json_success(
             [
-                'message'  => __( 'Import started. You can continue browsing while we process the file.', 'tta' ),
+                'message'  => __( 'Import started. Please keep this page open while we process the file.', 'tta' ),
                 'job_id'   => $job_id,
                 'total'    => $total_rows,
             ]

--- a/includes/ajax/handlers/class-ajax-partners.php
+++ b/includes/ajax/handlers/class-ajax-partners.php
@@ -874,7 +874,7 @@ class TTA_Ajax_Partners {
 
         $members = $wpdb->get_results(
             $wpdb->prepare(
-                "SELECT id, first_name, last_name, email, joined_at, wpuserid FROM {$members_table} WHERE {$where_sql} ORDER BY id DESC LIMIT %d OFFSET %d",
+                "SELECT id, first_name, last_name, email, joined_at, wpuserid FROM {$members_table} WHERE {$where_sql} ORDER BY first_name ASC, last_name ASC, id ASC LIMIT %d OFFSET %d",
                 array_merge( $params, [ $per_page, $offset ] )
             ),
             ARRAY_A

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -89,6 +89,10 @@ echo do_shortcode( $header_shortcode );
     .page-template-partner-admin-page-template #tta-license-reset-btn {
       width: 130px;
     }
+
+    .page-template-partner-admin-page-template #tta-license-reset-btn {
+      margin-top: 10px;
+    }
   }
 </style>
 <?php

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -123,7 +123,7 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
   <div class="tta-account-access-inner">
     <?php if ( ! is_user_logged_in() ) : ?>
       <section class="tta-login-column">
-        <h1 class="tta-section-title"><?php esc_html_e( 'Already Have an Account? Log In Below!', 'tta' ); ?></h1>
+        <h1 class="tta-section-title"><?php esc_html_e( 'Welcome, Partner! Log in Below.', 'tta' ); ?></h1>
         <p class="tta-section-intro">
           <?php
           echo wp_kses(

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -15,6 +15,52 @@ get_header();
 
 $header_shortcode = '[vc_row full_width="stretch_row_content_no_spaces" css=".vc_custom_1670382516702{background-image: url(https://trying-to-adult-rva-2025.local/wp-content/uploads/2022/12/IMG-4418.png?id=70) !important;background-position: center !important;background-repeat: no-repeat !important;background-size: cover !important;}"][vc_column][vc_empty_space height="300px" el_id="jre-header-title-empty"][vc_column_text css_animation="slideInLeft" el_id="jre-homepage-id-1" css=".vc_custom_1671885403487{margin-left: 50px !important;padding-left: 50px !important;}"]<p id="jre-homepage-id-3">PARTNER ADMIN</p>[/vc_column_text][/vc_column][/vc_row]';
 echo do_shortcode( $header_shortcode );
+?>
+<style>
+  .tta-partner-admin-page .vc_custom_1670382516702 {
+    background-color: #000;
+  }
+
+  .tta-partner-admin-page #jre-homepage-id-1 {
+    margin-left: 50px !important;
+    padding-left: 50px !important;
+  }
+
+  .tta-partner-admin-page #single-blocks > div > div > div.vc_row.wpb_row.vc_row-fluid.vc_custom_1670382516702.wpex-vc-full-width-row.wpex-vc-full-width-row--no-padding.wpex-relative.wpex-vc_row-has-fill.wpex-vc-reset-negative-margin > div {
+    background-color: #000;
+  }
+
+  .tta-partner-admin-page #jre-homepage-id-3 {
+    bottom: 65px;
+  }
+
+  @media (max-width: 960px) {
+    .tta-partner-admin-page #jre-homepage-id-1 {
+      margin-left: 0 !important;
+      padding-left: 0 !important;
+    }
+
+    .tta-partner-admin-page #jre-homepage-id-3 {
+      bottom: 0 !important;
+    }
+
+    .tta-partner-admin-page #single-blocks > div > div > div.vc_row.wpb_row.vc_row-fluid.vc_custom_1670382516702.wpex-vc-full-width-row.wpex-vc-full-width-row--no-padding.wpex-relative.wpex-vc_row-has-fill.wpex-vc-reset-negative-margin > div {
+      height: 245px;
+    }
+  }
+
+  @media (max-width: 530px) {
+    .tta-partner-admin-page #jre-homepage-id-1 #jre-homepage-id-3 {
+      font-size: 50px;
+      padding: 0 15px;
+    }
+
+    .tta-partner-admin-page #jre-homepage-id-3 {
+      bottom: 20px !important;
+    }
+  }
+</style>
+<?php
 
 $redirect_url = get_permalink();
 $login_form   = wp_login_form(

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -146,6 +146,7 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
                   'employmentSuccess' => __( 'Member marked as no longer employed.', 'tta' ),
                   'employmentError'   => __( 'Unable to update the member. Please try again.', 'tta' ),
                   'employmentConfirm' => __( "Are you sure you want to remove this person? They'll lose their Membership and will need to sign up for their own paid Membership if they want to keep Membership benefits.", 'tta' ),
+                  'singleMissing' => __( "Whoops - looks like some info is missing! Please make sure you've provided a first name, last name, and email address.", 'tta' ),
               ];
               ?>
               <script>
@@ -247,13 +248,13 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
                     <div class="tta-license-single-add">
                       <h3><?php esc_html_e( 'Add an Individual Member', 'tta' ); ?></h3>
                       <p class="tta-section-intro">
-                        <?php esc_html_e( 'Provide a first name, last name, and email address below to add members individually.', 'tta' ); ?>
+                        <?php esc_html_e( 'Provide a First Name, Last Name, and Email address below to add members individually.', 'tta' ); ?>
                       </p>
                       <div class="tta-license-single-fields">
                         <input type="text" id="tta-single-first" placeholder="<?php esc_attr_e( 'First Name', 'tta' ); ?>" />
                         <input type="text" id="tta-single-last" placeholder="<?php esc_attr_e( 'Last Name', 'tta' ); ?>" />
                         <input type="text" id="tta-single-email" placeholder="<?php esc_attr_e( 'Email', 'tta' ); ?>" />
-                        <button type="button" class="tta-button tta-button-primary" id="tta-single-add-btn"><?php esc_html_e( 'Add Member', 'tta' ); ?></button>
+                        <button type="button" class="tta-button" id="tta-single-add-btn"><?php esc_html_e( 'Add Member', 'tta' ); ?></button>
                         <img class="tta-admin-progress-spinner-svg" id="tta-single-spinner" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" />
                       </div>
                       <p id="tta-single-response" class="tta-admin-progress-response-p" role="status" aria-live="polite"></p>
@@ -422,7 +423,7 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
       var last = $singleLast.val();
       var email = $singleEmail.val();
       if (!first || !last || !email) {
-        singleError(uploadCfg.emptyFile || 'Please provide first name, last name, and email.');
+        singleError(uploadCfg.singleMissing || 'Please provide first name, last name, and email.');
         return;
       }
       $singleBtn.prop('disabled', true);

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -262,6 +262,14 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
 
                     <div class="tta-license-search">
                       <h3><?php esc_html_e( 'All Members', 'tta' ); ?></h3>
+                      <p class="tta-section-intro">
+                        <?php
+                        echo wp_kses(
+                            __( 'Below are the Members you&#039;ve uploaded or added individually. Search by First Name, Last Name, or Email address. If a Member&#039;s Status reads as "Active", that means they&#039;ve taken advantage of their Membership benefits and created an account! If a Member is no longer eligible for their Membership benefits, simply search for that member and click the "No Longer Employed" button.', 'tta' ),
+                            []
+                        );
+                        ?>
+                      </p>
                       <div class="tta-license-search-fields">
                         <input type="text" id="tta-search-first" placeholder="<?php esc_attr_e( 'First Name', 'tta' ); ?>" />
                         <input type="text" id="tta-search-last" placeholder="<?php esc_attr_e( 'Last Name', 'tta' ); ?>" />

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -59,6 +59,37 @@ echo do_shortcode( $header_shortcode );
       bottom: 20px !important;
     }
   }
+
+  @media (max-width: 1200px) {
+    .page-template-partner-admin-page-template .tta-dashboard-sidebar {
+      flex: 0 0 150px;
+      display: block;
+    }
+
+    .page-template-partner-admin-page-template .form-table.tta-partner-profile-table td {
+      min-width: 200px;
+      margin-left: auto;
+      margin-right: auto;
+      text-align: center;
+      display: block;
+    }
+
+    .page-template-partner-admin-page-template #tta-single-add-btn,
+    .page-template-partner-admin-page-template #tta-license-search-btn {
+      display: block;
+      margin-top: 20px;
+    }
+
+    .page-template-partner-admin-page-template .tta-license-search-fields input,
+    .page-template-partner-admin-page-template .tta-license-single-fields input {
+      margin-top: 10px;
+    }
+
+    .page-template-partner-admin-page-template #tta-license-search-btn,
+    .page-template-partner-admin-page-template #tta-license-reset-btn {
+      width: 130px;
+    }
+  }
 </style>
 <?php
 

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -145,6 +145,7 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
                   'paginationLabel' => __( 'Page %1$d of %2$d', 'tta' ),
                   'employmentSuccess' => __( 'Member marked as no longer employed.', 'tta' ),
                   'employmentError'   => __( 'Unable to update the member. Please try again.', 'tta' ),
+                  'employmentConfirm' => __( "Are you sure you want to remove this person? They'll lose their Membership and will need to sign up for their own paid Membership if they want to keep Membership benefits.", 'tta' ),
               ];
               ?>
               <script>
@@ -531,6 +532,10 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
       var $btn = $(this);
       var memberId = parseInt($btn.data('member-id'), 10);
       if (!memberId) {
+        return;
+      }
+      var confirmMessage = uploadCfg.employmentConfirm || 'Are you sure you want to remove this person?';
+      if (!window.confirm(confirmMessage)) {
         return;
       }
       var $panel = $btn.closest('.tta-license-panel');

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -92,13 +92,14 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
               <h2><?php echo esc_html( $partner['company_name'] ); ?></h2>
               <p>
                 <?php
-                echo esc_html(
-                    sprintf(
+                printf(
+                    esc_html__(
                         /* translators: 1: partner contact first name, 2: partner company name */
-                        __( "Welcome %1$s! We're excited to have you and %2$s as one of our valued Partners.", 'tta' ),
-                        $partner['contact_first_name'],
-                        $partner['company_name']
-                    )
+                        "Welcome %1$s! We're excited to have you and %2$s as one of our valued Partners.",
+                        'tta'
+                    ),
+                    esc_html( $partner['contact_first_name'] ?? '' ),
+                    esc_html( $partner['company_name'] ?? '' )
                 );
                 ?>
               </p>

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -90,19 +90,7 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
           <section class="tta-partner-admin-placeholder">
             <div class="tta-member-dashboard-wrap notranslate" data-nosnippet>
               <h2><?php echo esc_html( $partner['company_name'] ); ?></h2>
-              <p>
-                <?php
-                printf(
-                    esc_html__(
-                        /* translators: 1: partner contact first name, 2: partner company name */
-                        "Welcome %1$s! We're excited to have you and %2$s as one of our valued Partners.",
-                        'tta'
-                    ),
-                    esc_html( $partner['contact_first_name'] ?? '' ),
-                    esc_html( $partner['company_name'] ?? '' )
-                );
-                ?>
-              </p>
+              <p><?php echo esc_html( sprintf( /* translators: %s: partner contact first name */ __( 'Welcome, %s!', 'tta' ), $partner['contact_first_name'] ) ); ?></p>
               <?php
               $members_table = $wpdb->prefix . 'tta_members';
               $identifier    = $partner['uniquecompanyidentifier'] ?? '';

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -196,6 +196,7 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
                   'employmentError'   => __( 'Unable to update the member. Please try again.', 'tta' ),
                   'employmentConfirm' => __( "Are you sure you want to remove this person? They'll lose their Membership and will need to sign up for their own paid Membership if they want to keep Membership benefits.", 'tta' ),
                   'singleMissing' => __( "Whoops - looks like some info is missing! Please make sure you've provided a first name, last name, and email address.", 'tta' ),
+                  'processingNote' => __( 'Import started. Please keep this page open while we process the file.', 'tta' ),
               ];
               ?>
               <script>
@@ -434,10 +435,9 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
         dataType: 'json'
       }).done(function(res){
         $btn.prop('disabled', false);
-        $spinner.hide();
         // Keep progress spinners visible until job completes; hide only on fail or completion.
         if (res && res.success) {
-          showSuccess(res.data && res.data.message ? res.data.message : (uploadCfg.success || 'Import started. Please remain on this page while we process the file.'));
+          showSuccess(res.data && res.data.message ? res.data.message : (uploadCfg.processingNote || 'Import started. Please keep this page open while we process the file.'));
           currentJob = res.data && res.data.job_id ? res.data.job_id : null;
           if (currentJob) {
             startPolling();
@@ -448,12 +448,13 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
           showError(msg);
           updateProgress(0);
           $progressSpinner.hide();
+          $spinner.hide();
         }
       }).fail(function(){
         $btn.prop('disabled', false);
-        $spinner.hide();
         $progressSpinner.hide();
         $progressHolderSpinner.fadeOut(200);
+        $spinner.hide();
         showError(uploadCfg.error || 'Upload failed.');
       });
     });
@@ -673,6 +674,7 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
             pollTimer = null;
             $progressSpinner.hide();
             $progressHolderSpinner.fadeOut(200);
+            $spinner.hide();
             fetchMembers(1);
           }
         });

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -324,6 +324,15 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
     $progressHolderSpinner.css({ display: 'none', opacity: 0 });
     $singleSpinner.hide();
 
+    function capitalizeWords(value) {
+      if (!value) {
+        return '';
+      }
+      return value.toString().toLowerCase().replace(/\b\w/g, function(letter){
+        return letter.toUpperCase();
+      });
+    }
+
     function resetState() {
       $resp.removeClass('error updated').text('');
       $respMsg.removeClass('error updated').text('');
@@ -450,16 +459,18 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
       var html = '<div class="tta-license-accordion">';
       
       members.forEach(function(m){
-        var name = ((m.first_name || '') + ' ' + (m.last_name || '')).trim();
+        var firstName = capitalizeWords(m.first_name || '');
+        var lastName = capitalizeWords(m.last_name || '');
+        var name = (firstName + ' ' + lastName).trim();
         html += '<div class="tta-license-item">';
         html += '<button type="button" class="tta-license-toggle" aria-expanded="false">' +
-                '<span class="tta-license-col tta-license-col-name tta-license-col-firstname">' + (m.first_name || '') + '</span>' +
-                '<span class="tta-license-col tta-license-col-name tta-license-col-lastname">' + (m.last_name || '') + ' - </span>' +
+                '<span class="tta-license-col tta-license-col-name tta-license-col-firstname">' + firstName + '</span>' +
+                '<span class="tta-license-col tta-license-col-name tta-license-col-lastname">' + lastName + ' - </span>' +
                 '<span class="tta-license-col tta-license-col-email">' + (m.email || '') + '</span>' +
                 '</button>';
         html += '<div class="tta-license-panel" hidden>';
-        html += '<p><strong><?php echo esc_js( __( 'First Name', 'tta' ) ); ?>:</strong> ' + (m.first_name || '') + '</p>';
-        html += '<p><strong><?php echo esc_js( __( 'Last Name', 'tta' ) ); ?>:</strong> ' + (m.last_name || '') + '</p>';
+        html += '<p><strong><?php echo esc_js( __( 'First Name', 'tta' ) ); ?>:</strong> ' + firstName + '</p>';
+        html += '<p><strong><?php echo esc_js( __( 'Last Name', 'tta' ) ); ?>:</strong> ' + lastName + '</p>';
         html += '<p><strong><?php echo esc_js( __( 'Email', 'tta' ) ); ?>:</strong> ' + (m.email || '') + '</p>';
         if (m.joined_at){
           var joined = new Date(m.joined_at.replace(' ', 'T'));

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -90,7 +90,18 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
           <section class="tta-partner-admin-placeholder">
             <div class="tta-member-dashboard-wrap notranslate" data-nosnippet>
               <h2><?php echo esc_html( $partner['company_name'] ); ?></h2>
-              <p><?php echo esc_html( sprintf( /* translators: %s: partner contact first name */ __( 'Welcome, %s!', 'tta' ), $partner['contact_first_name'] ) ); ?></p>
+              <p>
+                <?php
+                echo esc_html(
+                    sprintf(
+                        /* translators: 1: partner contact first name, 2: partner company name */
+                        __( "Welcome %1$s! We're excited to have you and %2$s as one of our valued Partners.", 'tta' ),
+                        $partner['contact_first_name'],
+                        $partner['company_name']
+                    )
+                );
+                ?>
+              </p>
               <?php
               $members_table = $wpdb->prefix . 'tta_members';
               $identifier    = $partner['uniquecompanyidentifier'] ?? '';

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -196,6 +196,9 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
                   <div id="tab-licenses" class="tta-dashboard-section notranslate" data-nosnippet style="display:none;">
                     <div class="tta-license-section tta-license-summary">
                       <h3><?php esc_html_e( 'Member License Info', 'tta' ); ?></h3>
+                      <p class="tta-section-intro">
+                        <?php esc_html_e( 'Below is the info about your Licenses. One License is assigned to each Member. Active Licenses represent the amount of Members that have utilized their Membership benefits and created an account.', 'tta' ); ?>
+                      </p>
                       <ul>
                         <li><strong><?php esc_html_e( 'License Limit:', 'tta' ); ?></strong> <?php echo $license_limit > 0 ? esc_html( number_format_i18n( $license_limit ) ) : esc_html__( 'Unlimited', 'tta' ); ?></li>
                         <li><strong><?php esc_html_e( 'Used Licenses:', 'tta' ); ?></strong> <?php echo esc_html( number_format_i18n( $counts['total'] ) ); ?></li>

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -286,9 +286,6 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
                           <div class="tta-admin-progress-response-p-message-holder">
                             <p id="tta-license-upload-response-message" class="tta-admin-progress-response-p-message" role="status" aria-live="polite"></p>
                           </div>
-                          <div class="tta-license-upload-progress-bar-div">
-                            <p id="tta-license-upload-response" class="tta-admin-progress-response-p" role="status" aria-live="polite" style="width:0%;"></p>
-                          </div>
                         </div>
                         <div class="tta-progress-wrap" aria-live="polite">
                           <div class="tta-progress-bar" id="tta-upload-progress" style="width:0%" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
@@ -360,7 +357,6 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
     var uploadCfg = window.TTA_Partner_Licenses || {};
     var $file = $('#tta-license-file');
     var $btn = $('#tta-license-upload-btn');
-    var $resp = $('#tta-license-upload-response');
     var $respMsg = $('#tta-license-upload-response-message');
     var $spinner = $('.tta-license-upload .tta-admin-progress-spinner-svg');
     var $progressBar = $('#tta-license-upload-response');
@@ -398,9 +394,7 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
     }
 
     function resetState() {
-      $resp.removeClass('error updated').text('');
       $respMsg.removeClass('error updated').text('');
-      $resp.css('opacity', 0);
     }
 
     function showError(msg) {

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -17,45 +17,45 @@ $header_shortcode = '[vc_row full_width="stretch_row_content_no_spaces" css=".vc
 echo do_shortcode( $header_shortcode );
 ?>
 <style>
-  .tta-partner-admin-page .vc_custom_1670382516702 {
+  .page-template-partner-admin-page-template .vc_custom_1670382516702 {
     background-color: #000;
   }
 
-  .tta-partner-admin-page #jre-homepage-id-1 {
+  .page-template-partner-admin-page-template #jre-homepage-id-1 {
     margin-left: 50px !important;
     padding-left: 50px !important;
   }
 
-  .tta-partner-admin-page #single-blocks > div > div > div.vc_row.wpb_row.vc_row-fluid.vc_custom_1670382516702.wpex-vc-full-width-row.wpex-vc-full-width-row--no-padding.wpex-relative.wpex-vc_row-has-fill.wpex-vc-reset-negative-margin > div {
+  .page-template-partner-admin-page-template #single-blocks > div > div > div.vc_row.wpb_row.vc_row-fluid.vc_custom_1670382516702.wpex-vc-full-width-row.wpex-vc-full-width-row--no-padding.wpex-relative.wpex-vc_row-has-fill.wpex-vc-reset-negative-margin > div {
     background-color: #000;
   }
 
-  .tta-partner-admin-page #jre-homepage-id-3 {
+  .page-template-partner-admin-page-template #jre-homepage-id-3 {
     bottom: 65px;
   }
 
   @media (max-width: 960px) {
-    .tta-partner-admin-page #jre-homepage-id-1 {
+    .page-template-partner-admin-page-template #jre-homepage-id-1 {
       margin-left: 0 !important;
       padding-left: 0 !important;
     }
 
-    .tta-partner-admin-page #jre-homepage-id-3 {
+    .page-template-partner-admin-page-template #jre-homepage-id-3 {
       bottom: 0 !important;
     }
 
-    .tta-partner-admin-page #single-blocks > div > div > div.vc_row.wpb_row.vc_row-fluid.vc_custom_1670382516702.wpex-vc-full-width-row.wpex-vc-full-width-row--no-padding.wpex-relative.wpex-vc_row-has-fill.wpex-vc-reset-negative-margin > div {
+    .page-template-partner-admin-page-template #single-blocks > div > div > div.vc_row.wpb_row.vc_row-fluid.vc_custom_1670382516702.wpex-vc-full-width-row.wpex-vc-full-width-row--no-padding.wpex-relative.wpex-vc_row-has-fill.wpex-vc-reset-negative-margin > div {
       height: 245px;
     }
   }
 
   @media (max-width: 530px) {
-    .tta-partner-admin-page #jre-homepage-id-1 #jre-homepage-id-3 {
+    .page-template-partner-admin-page-template #jre-homepage-id-1 #jre-homepage-id-3 {
       font-size: 50px;
       padding: 0 15px;
     }
 
-    .tta-partner-admin-page #jre-homepage-id-3 {
+    .page-template-partner-admin-page-template #jre-homepage-id-3 {
       bottom: 20px !important;
     }
   }

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -13,6 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 get_header();
 
+$header_shortcode = '[vc_row full_width="stretch_row_content_no_spaces" css=".vc_custom_1670382516702{background-image: url(https://trying-to-adult-rva-2025.local/wp-content/uploads/2022/12/IMG-4418.png?id=70) !important;background-position: center !important;background-repeat: no-repeat !important;background-size: cover !important;}"][vc_column][vc_empty_space height="300px" el_id="jre-header-title-empty"][vc_column_text css_animation="slideInLeft" el_id="jre-homepage-id-1" css=".vc_custom_1671885403487{margin-left: 50px !important;padding-left: 50px !important;}"]<p id="jre-homepage-id-3">PARTNER ADMIN</p>[/vc_column_text][/vc_column][/vc_row]';
+echo do_shortcode( $header_shortcode );
+
 $redirect_url = get_permalink();
 $login_form   = wp_login_form(
     [

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -93,6 +93,18 @@ echo do_shortcode( $header_shortcode );
     .page-template-partner-admin-page-template #tta-license-reset-btn {
       margin-top: 10px;
     }
+
+    .page-template-partner-admin-page-template .tta-license-panel p {
+      display: block;
+      margin-right: 10px;
+      margin-left: 10px;
+      margin-bottom: 10px;
+    }
+
+    .page-template-partner-admin-page-template .tta-member-dashboard-wrap {
+      padding-left: 0;
+      padding-right: 0;
+    }
   }
 </style>
 <?php

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -359,7 +359,7 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
     var $btn = $('#tta-license-upload-btn');
     var $respMsg = $('#tta-license-upload-response-message');
     var $spinner = $('.tta-license-upload .tta-admin-progress-spinner-svg');
-    var $progressBar = $('#tta-license-upload-response');
+    var $progressBar = $('#tta-upload-progress');
     var $progressSpinner = $('#tta-upload-progress-spinner');
     var $progressHolderSpinner = $('.tta-license-upload-progress-holder .tta-admin-progress-spinner-svg');
     var currentJob = null;
@@ -424,7 +424,6 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
       $progressSpinner.show();
       $progressHolderSpinner.stop(true, true).css({ display: 'inline-block' }).fadeTo(200, 1);
       updateProgress(0);
-      $resp.css('opacity', 1);
 
       $.ajax({
         url: uploadCfg.ajaxUrl,

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -246,6 +246,9 @@ $lost_pw_url  = wp_lostpassword_url( $redirect_url );
 
                     <div class="tta-license-single-add">
                       <h3><?php esc_html_e( 'Add an Individual Member', 'tta' ); ?></h3>
+                      <p class="tta-section-intro">
+                        <?php esc_html_e( 'Provide a first name, last name, and email address below to add members individually.', 'tta' ); ?>
+                      </p>
                       <div class="tta-license-single-fields">
                         <input type="text" id="tta-single-first" placeholder="<?php esc_attr_e( 'First Name', 'tta' ); ?>" />
                         <input type="text" id="tta-single-last" placeholder="<?php esc_attr_e( 'Last Name', 'tta' ); ?>" />

--- a/includes/frontend/templates/partner-login-page-template.php
+++ b/includes/frontend/templates/partner-login-page-template.php
@@ -15,6 +15,55 @@ global $post, $wpdb;
 
 get_header();
 
+$header_shortcode = '[vc_row full_width="stretch_row_content_no_spaces" css=".vc_custom_1670382516702{background-image: url(https://trying-to-adult-rva-2025.local/wp-content/uploads/2022/12/IMG-4418.png?id=70) !important;background-position: center !important;background-repeat: no-repeat !important;background-size: cover !important;}"][vc_column][vc_empty_space height="300px" el_id="jre-header-title-empty"][vc_column_text css_animation="slideInLeft" el_id="jre-homepage-id-1" css=".vc_custom_1671885403487{margin-left: 50px !important;padding-left: 50px !important;}"]<p id="jre-homepage-id-3">BECOME A MEMBER</p>[/vc_column_text][/vc_column][/vc_row]';
+echo do_shortcode( $header_shortcode );
+?>
+<style>
+  .page-template-partner-login-page-template .vc_custom_1670382516702 {
+    background-color: #000;
+  }
+
+  .page-template-partner-login-page-template #jre-homepage-id-1 {
+    margin-left: 50px !important;
+    padding-left: 50px !important;
+  }
+
+  .page-template-partner-login-page-template #single-blocks > div > div > div.vc_row.wpb_row.vc_row-fluid.vc_custom_1670382516702.wpex-vc-full-width-row.wpex-vc-full-width-row--no-padding.wpex-relative.wpex-vc_row-has-fill.wpex-vc-reset-negative-margin > div {
+    background-color: #000;
+  }
+
+  .page-template-partner-login-page-template #jre-homepage-id-3 {
+    bottom: 65px;
+  }
+
+  @media (max-width: 960px) {
+    .page-template-partner-login-page-template #jre-homepage-id-1 {
+      margin-left: 0 !important;
+      padding-left: 0 !important;
+    }
+
+    .page-template-partner-login-page-template #jre-homepage-id-3 {
+      bottom: 0 !important;
+    }
+
+    .page-template-partner-login-page-template #single-blocks > div > div > div.vc_row.wpb_row.vc_row-fluid.vc_custom_1670382516702.wpex-vc-full-width-row.wpex-vc-full-width-row--no-padding.wpex-relative.wpex-vc_row-has-fill.wpex-vc-reset-negative-margin > div {
+      height: 245px;
+    }
+  }
+
+  @media (max-width: 530px) {
+    .page-template-partner-login-page-template #jre-homepage-id-1 #jre-homepage-id-3 {
+      font-size: 50px;
+      padding: 0 15px;
+    }
+
+    .page-template-partner-login-page-template #jre-homepage-id-3 {
+      bottom: 20px !important;
+    }
+  }
+</style>
+<?php
+
 $page_id = isset( $post->ID ) ? intval( $post->ID ) : 0;
 $partner = TTA_Cache::remember(
     'partner_login_page_' . $page_id,


### PR DESCRIPTION
### Motivation
- Provide partner admins a way to mark members as offboarded from the Partner Admin UI and remove their premium membership.
- Persist the offboard action by updating the `tta_members` row to set `membership_level` to `free` and clear `subscription_status`.
- Restrict the action to the partner contact or site administrators and surface success/error messages in the UI.
- Keep the plugin cache consistent after member updates by flushing relevant caches.

### Description
- Added UI wiring in `includes/frontend/templates/partner-admin-page-template.php` to render a `No Longer Employed` button per member, client-side click handler, and new localized strings and nonce (`updateNonce`) exposed to `window.TTA_Partner_Licenses`.
- Implemented an authenticated AJAX endpoint `tta_partner_end_employment` and the handler `end_member_employment` in `includes/ajax/handlers/class-ajax-partners.php` that validates permissions, verifies the partner for the current page, and performs a prepared `UPDATE` to set `membership_level = 'free'` and `subscription_status = NULL` for the matching `tta_members` record.
- The server handler uses `TTA_Cache::flush()` after a successful update and returns JSON success/error messages consumed by the UI.
- Documented the feature in `docs/PartnerAdminPage.md` and added translatable UI messages (`employmentSuccess`, `employmentError`).

### Testing
- No automated tests (PHPUnit or CI) were executed as part of this change.
- Basic static inspection and repository updates were committed; runtime verification in a WordPress environment is recommended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eda9382c08320856979203d817883)