### PR TITLE
Remove redirect parameters from lost password links

### DIFF
--- a/assets/css/frontend/style.css
+++ b/assets/css/frontend/style.css
@@ -112,6 +112,13 @@
   font-weight:600;
 }
 
+.page-template-host-checkin-template #tta-login-wrap{
+  text-align:center;
+  margin-top:20px;
+  padding-left:20px;
+  padding-right:20px;
+}
+
 .button.tta-mark-attendance{
   display: block;
   margin-bottom: 10px;
@@ -299,4 +306,3 @@
 .tta-header-logout-div {
   display: inline-block;
 }
-

--- a/docs/EventCheckInAdmin.md
+++ b/docs/EventCheckInAdmin.md
@@ -7,7 +7,8 @@ update each record via AJAX. Attendance status writes back to the
 `tta_attendees` table and the interface updates instantly without a full refresh.
 
 Visitors who aren't logged in are shown a styled login form with a **Forgot your
-password?** link so volunteers can quickly authenticate from any device.
+password?** link that goes to the default WordPress reset screen without a
+`redirect_to` parameter so volunteers can quickly authenticate from any device.
 
 Events remain listed for 24 hours after their scheduled end time, giving hosts
 extra time to check people in or mark no-shows before the event drops off the

--- a/docs/LoginRegisterPage.md
+++ b/docs/LoginRegisterPage.md
@@ -19,7 +19,7 @@ flow.
 - **WordPress login form** on the left-hand column. Users are redirected to
   the Events Listings page (`/events`) after a successful login. A “Forgot
 your password?” link points to the standard WordPress password reset
-screen.
+screen and intentionally omits any `redirect_to` parameter.
 - **Custom registration form** on the right-hand column that mirrors the
   validation rules used across the site (matching email/password pairs and
   strong password requirements). Registration happens via the existing

--- a/docs/PartnerAdminPage.md
+++ b/docs/PartnerAdminPage.md
@@ -8,7 +8,9 @@ Page Attributes dropdown.
 
 ## Behavior
 - **Login-first experience:** Visitors who are not logged in see the standard
-  WordPress login form. Successful logins return to the same page.
+  WordPress login form with a **Forgot your password?** link that routes to
+  the default WordPress reset screen without a `redirect_to` parameter.
+  Successful logins return to the same page.
 - **Access control:** Only the partner contact stored on the related
   `tta_partners.wpuserid` row or site administrators (`manage_options`) can
   view partner content; others see an access-restricted notice.

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -738,7 +738,7 @@ $form_html = wp_login_form( [
 ] );
 
 // 2. Build the lost-password link
-$lost_pw_url = wp_lostpassword_url( get_permalink() ); // redirect back here after reset
+$lost_pw_url = wp_lostpassword_url();
 $lost_pw_html = sprintf(
     '<p class="login-lost-password"><a href="%s">%s</a></p>',
     esc_url( $lost_pw_url ),

--- a/includes/frontend/templates/host-checkin-template.php
+++ b/includes/frontend/templates/host-checkin-template.php
@@ -15,7 +15,7 @@ if ( ! $context['is_logged_in'] ) {
     echo do_shortcode( $header_shortcode );
 
     $form_html   = wp_login_form( [ 'echo' => false, 'redirect' => get_permalink() ] );
-    $lost_pw_url = wp_lostpassword_url( get_permalink() );
+    $lost_pw_url = wp_lostpassword_url();
     echo '<div id="tta-login-wrap" class="tta-login-wrap">' . $form_html . '<p class="login-lost-password"><a href="' . esc_url( $lost_pw_url ) . '">' . esc_html__( 'Forgot your password?', 'tta' ) . '</a></p></div>';
 
     get_footer();
@@ -85,4 +85,3 @@ echo do_shortcode( $header_shortcode );
 </div>
 <?php
 get_footer();
-

--- a/includes/frontend/templates/login-register-page-template.php
+++ b/includes/frontend/templates/login-register-page-template.php
@@ -25,7 +25,7 @@ $login_form   = wp_login_form(
         'remember' => true,
     ]
 );
-$lost_pw_url = wp_lostpassword_url( $redirect_url );
+$lost_pw_url = wp_lostpassword_url();
 ?>
 <div class="tta-account-access">
   <div class="tta-account-access-inner">

--- a/includes/frontend/templates/partner-admin-page-template.php
+++ b/includes/frontend/templates/partner-admin-page-template.php
@@ -117,7 +117,7 @@ $login_form   = wp_login_form(
         'remember' => true,
     ]
 );
-$lost_pw_url  = wp_lostpassword_url( $redirect_url );
+$lost_pw_url  = wp_lostpassword_url();
 ?>
 <div class="tta-account-access tta-partner-admin-page">
   <div class="tta-account-access-inner">

--- a/includes/frontend/views/tab-login.php
+++ b/includes/frontend/views/tab-login.php
@@ -12,7 +12,7 @@ $form_html = wp_login_form(
         'form_id'  => $form_id,
     ]
 );
-$lost_pw_url = wp_lostpassword_url( home_url( '/member-dashboard/?tab=' . $tab_slug ) );
+$lost_pw_url = wp_lostpassword_url();
 ?>
 <div id="tab-<?php echo esc_attr( $tab_slug ); ?>" class="tta-dashboard-section notranslate" data-nosnippet>
   <section class="tta-message-center tta-login-accordion tta-login-message">

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -5650,7 +5650,7 @@ function tta_render_login_register_section( $redirect ) {
         ]
     );
 
-    $lost_pw_url = wp_lostpassword_url( $redirect );
+    $lost_pw_url = wp_lostpassword_url();
 
     ob_start();
     ?>
@@ -5732,7 +5732,7 @@ function tta_render_membership_checkout_section( $redirect ) {
         ]
     );
 
-    $lost_pw_url = wp_lostpassword_url( $redirect );
+    $lost_pw_url = wp_lostpassword_url();
 
     ob_start();
     ?>


### PR DESCRIPTION
### Motivation
- Ensure lost-password links do not include a `redirect_to` parameter so password reset flows use the default WordPress behavior and avoid unintended post-reset redirects.
- Preserve existing post-login redirect semantics for non-admins via the existing filter implementation.
- Improve security and user experience by avoiding injected redirect destinations in reset links.
- Update documentation to reflect the intentional removal of `redirect_to` from these links.

### Description
- Replaced calls like `wp_lostpassword_url( $redirect )` with `wp_lostpassword_url()` in the login-related helpers and templates to remove `redirect_to` from reset links. Affected files include `includes/helpers.php`, `includes/frontend/views/tab-login.php`, `includes/frontend/templates/partner-admin-page-template.php`, `includes/frontend/templates/host-checkin-template.php`, `includes/frontend/templates/login-register-page-template.php`, and `includes/frontend/templates/event-page-template.php`.
- Updated documentation files `docs/LoginRegisterPage.md`, `docs/PartnerAdminPage.md`, and `docs/EventCheckInAdmin.md` to note that lost-password links intentionally omit the `redirect_to` parameter.
- Left the `tta_login_redirect` filter implementation (`includes/helpers.php`) unchanged to preserve post-login redirect behavior for non-admin users.
- Performed a code search to confirm no remaining `wp_lostpassword_url()` calls pass a redirect argument.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f756abd88320a110dffc1381f4b6)