### PR TITLE
Add Google Calendar link to event page sidebar

### DIFF
--- a/assets/images/public/event-page-icons/googlecalendar.svg
+++ b/assets/images/public/event-page-icons/googlecalendar.svg
@@ -1,0 +1,7 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title>Google Calendar</title>
+  <rect x="3" y="5" width="26" height="24" rx="3" fill="#ffffff" stroke="#1a1a1a" stroke-width="2"/>
+  <rect x="3" y="9" width="26" height="5" fill="#4285F4"/>
+  <circle cx="11" cy="19" r="4" fill="#34A853"/>
+  <path d="M17 19h8" stroke="#EA4335" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/assets/images/public/event-page-icons/ics-calendar.svg
+++ b/assets/images/public/event-page-icons/ics-calendar.svg
@@ -1,0 +1,7 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title>Calendar Download</title>
+  <rect x="3" y="5" width="26" height="24" rx="3" fill="#ffffff" stroke="#1a1a1a" stroke-width="2"/>
+  <rect x="3" y="9" width="26" height="5" fill="#5f6368"/>
+  <path d="M16 15v7" stroke="#1a1a1a" stroke-width="2" stroke-linecap="round"/>
+  <path d="M12 19l4 4 4-4" stroke="#1a1a1a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/js/backend/admin.js
+++ b/assets/js/backend/admin.js
@@ -1599,6 +1599,8 @@ $(document).on('click', '.tta-remove-waitlist-entry', function(e){
         '{event_address}': ev.address || '123 Main St',
         '{event_address_link}': ev.address_link || '#',
         '{event_link}': ev.page_url || '#',
+        '{event_google_calendar_link}': ev.google_calendar_url || '#',
+        '{event_ics_download_link}': ev.ics_download_url || '#',
         '{dashboard_profile_url}': ev.dashboard_profile_url || '#',
         '{dashboard_upcoming_url}': ev.dashboard_upcoming_url || '#',
         '{dashboard_waitlist_url}': ev.dashboard_waitlist_url || '#',

--- a/docs/EmailSMS.md
+++ b/docs/EmailSMS.md
@@ -96,6 +96,8 @@ Buttons labelled with tokens (e.g. `{event_name}`) insert placeholders into the 
 {event_address}
 {event_address_link}
 {event_link}
+{event_google_calendar_link}
+{event_ics_download_link}
 {dashboard_profile_url}
 {dashboard_upcoming_url}
 {dashboard_waitlist_url}
@@ -112,6 +114,9 @@ Buttons labelled with tokens (e.g. `{event_name}`) insert placeholders into the 
 ```
 
 `{event_address_link}` outputs a Google Maps URL for the event address.
+`{event_google_calendar_link}` outputs a Google Calendar URL that pre-fills the
+event details. `{event_ics_download_link}` generates a downloadable `.ics` file
+for the same event.
 
 Dashboard URL tokens accept an optional `anchor` attribute. For example:
 

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -14,6 +14,8 @@ and the address opens a Google Maps search.
 On screens wider than 768px this ad column sticks in view while scrolling but stays within its parent container. The StickySidebar library keeps the panel anchored until the bottom of its parent is reached. An extra 148px top offset keeps the ad clear of the site menu.
 The event details sidebar remains on the left and the main content occupies the
 center.
+The Event Details list now includes a Google Calendar link beneath the Location
+entry so visitors can add the event to their personal calendar.
 
 ## Current User Context Helper
 
@@ -110,5 +112,4 @@ Each event page outputs JSON‑LD Event schema. The markup includes the event na
 ## Related Events
 
 A grid of other upcoming events appears below the main content. Thumbnails are rendered with background images so they remain the same size even when the source photos vary. Each card links to its Event Page and shows the date beneath the title.
-
 

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -16,7 +16,8 @@ The event details sidebar remains on the left and the main content occupies the
 center.
 The Event Details list now includes Google Calendar and downloadable calendar
 file links beneath the Location entry so visitors can add the event to their
-personal calendar.
+personal calendar. The file download link triggers a dynamic `.ics` response so
+event updates are reflected at download time.
 
 ## Current User Context Helper
 

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -14,8 +14,9 @@ and the address opens a Google Maps search.
 On screens wider than 768px this ad column sticks in view while scrolling but stays within its parent container. The StickySidebar library keeps the panel anchored until the bottom of its parent is reached. An extra 148px top offset keeps the ad clear of the site menu.
 The event details sidebar remains on the left and the main content occupies the
 center.
-The Event Details list now includes a Google Calendar link beneath the Location
-entry so visitors can add the event to their personal calendar.
+The Event Details list now includes Google Calendar and downloadable calendar
+file links beneath the Location entry so visitors can add the event to their
+personal calendar.
 
 ## Current User Context Helper
 
@@ -112,4 +113,3 @@ Each event page outputs JSON‑LD Event schema. The markup includes the event na
 ## Related Events
 
 A grid of other upcoming events appears below the main content. Thumbnails are rendered with background images so they remain the same size even when the source photos vary. Each card links to its Event Page and shows the date beneath the title.
-

--- a/includes/admin/class-comms-admin.php
+++ b/includes/admin/class-comms-admin.php
@@ -327,6 +327,8 @@ class TTA_Comms_Admin {
             echo '<button type="button" class="button tta-insert-token" data-token="{event_address}">{event_address}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_address_link}">{event_address_link}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_link}">{event_link}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{event_google_calendar_link}">{event_google_calendar_link}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{event_ics_download_link}">{event_ics_download_link}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_date}">{event_date}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_time}">{event_time}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_type}">{event_type}</button> ';
@@ -428,6 +430,8 @@ class TTA_Comms_Admin {
         echo '<button type="button" class="button tta-insert-token" data-token="{event_address}">{event_address}</button> ';
         echo '<button type="button" class="button tta-insert-token" data-token="{event_address_link}">{event_address_link}</button> ';
         echo '<button type="button" class="button tta-insert-token" data-token="{event_link}">{event_link}</button> ';
+        echo '<button type="button" class="button tta-insert-token" data-token="{event_google_calendar_link}">{event_google_calendar_link}</button> ';
+        echo '<button type="button" class="button tta-insert-token" data-token="{event_ics_download_link}">{event_ics_download_link}</button> ';
         echo '<button type="button" class="button tta-insert-token" data-token="{event_date}">{event_date}</button> ';
         echo '<button type="button" class="button tta-insert-token" data-token="{event_time}">{event_time}</button> ';
         echo '<button type="button" class="button tta-insert-token" data-token="{event_type}">{event_type}</button> ';
@@ -646,4 +650,3 @@ class TTA_Comms_Admin {
         echo '</div>';
     }
 }
-

--- a/includes/classes/class-tta-assets.php
+++ b/includes/classes/class-tta-assets.php
@@ -147,6 +147,9 @@ class TTA_Assets {
                         $e['dashboard_past_url']    = home_url( '/member-dashboard/?tab=past' );
                         $e['dashboard_billing_url'] = home_url( '/member-dashboard/?tab=billing' );
                         $e['address_link']          = $e['address'] ? esc_url( 'https://maps.google.com/?q=' . rawurlencode( $e['address'] ) ) : '';
+                        $calendar_links             = tta_build_event_calendar_links( $e );
+                        $e['google_calendar_url']   = $calendar_links['google_calendar_url'];
+                        $e['ics_download_url']      = $calendar_links['ics_download_url'];
                         $e['date']                  = $e['date_formatted'];
                         $e['time']                  = $e['time_formatted'];
                         return $e;

--- a/includes/email/class-email-handler.php
+++ b/includes/email/class-email-handler.php
@@ -115,6 +115,7 @@ class TTA_Email_Handler {
      * @return array
      */
     protected function build_tokens( array $event, array $member, array $attendees, array $refund = [] ) {
+        $calendar_links = tta_build_event_calendar_links( $event );
         $tokens = [
             '{event_name}'           => $event['name'] ?? '',
             '{event_address}'        => $event['address'] ?? '',
@@ -122,6 +123,8 @@ class TTA_Email_Handler {
                 ? esc_url( 'https://maps.google.com/?q=' . rawurlencode( $event['address'] ) )
                 : '',
             '{event_link}'           => $event['page_url'] ?? '',
+            '{event_google_calendar_link}' => esc_url( $calendar_links['google_calendar_url'] ?? '' ),
+            '{event_ics_download_link}'    => esc_url( $calendar_links['ics_download_url'] ?? '' ),
             '{dashboard_profile_url}'  => home_url( '/member-dashboard/?tab=profile' ),
             '{dashboard_upcoming_url}' => home_url( '/member-dashboard/?tab=upcoming' ),
             '{dashboard_past_url}'       => home_url( '/member-dashboard/?tab=past' ),

--- a/includes/frontend/class-event-ics-download.php
+++ b/includes/frontend/class-event-ics-download.php
@@ -1,0 +1,142 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class TTA_Event_ICS_Download {
+    public static function init() {
+        add_action( 'template_redirect', [ __CLASS__, 'maybe_download' ] );
+    }
+
+    public static function maybe_download() {
+        $download_flag = tta_sanitize_text_field( $_GET['tta_event_ics'] ?? '' );
+        if ( '1' !== $download_flag ) {
+            return;
+        }
+
+        $event_ute_id = tta_sanitize_text_field( $_GET['event_ute_id'] ?? '' );
+        if ( '' === $event_ute_id ) {
+            wp_die( esc_html__( 'Missing event identifier.', 'tta' ) );
+        }
+
+        global $wpdb;
+        $events_table  = $wpdb->prefix . 'tta_events';
+        $archive_table = $wpdb->prefix . 'tta_events_archive';
+        $event         = TTA_Cache::remember( 'event_ics_' . $event_ute_id, function() use ( $wpdb, $events_table, $archive_table, $event_ute_id ) {
+            return $wpdb->get_row(
+                $wpdb->prepare(
+                    "SELECT * FROM {$events_table} WHERE ute_id = %s UNION SELECT * FROM {$archive_table} WHERE ute_id = %s LIMIT 1",
+                    $event_ute_id,
+                    $event_ute_id
+                ),
+                ARRAY_A
+            );
+        }, 600 );
+
+        if ( ! $event ) {
+            wp_die( esc_html__( 'Event not found.', 'tta' ) );
+        }
+
+        $raw_address       = $event['address'] ?? '';
+        $parts             = preg_split( '/\s*[-–]\s*/u', $raw_address );
+        $street            = trim( $parts[0] ?? '' );
+        $addr2             = trim( $parts[1] ?? '' );
+        $city              = trim( $parts[2] ?? '' );
+        $state             = trim( $parts[3] ?? '' );
+        $zip               = trim( $parts[4] ?? '' );
+        $street_full       = $street . ( $addr2 ? ' ' . $addr2 : '' );
+        $city_state_zip    = $city . ( $state || $zip ? ', ' : '' ) . $state . ( $zip ? ' ' . $zip : '' );
+        $formatted_address = trim( $street_full . ( $city_state_zip ? ' – ' . $city_state_zip : '' ) );
+
+        $tz       = wp_timezone();
+        $parts    = array_pad( explode( '|', $event['time'] ?? '' ), 2, '' );
+        $start    = $parts[0] ?? '';
+        $end      = $parts[1] ?? '';
+        $start_dt = date_create_from_format( 'Y-m-d H:i', $event['date'] . ' ' . ( $start ?: '00:00' ), $tz );
+        $start_ts = $start_dt ? $start_dt->getTimestamp() : strtotime( $event['date'] . ' ' . ( $start ?: '00:00' ) );
+        $end_dt   = ( $event['all_day_event'] ?? false )
+            ? $start_dt
+            : date_create_from_format( 'Y-m-d H:i', $event['date'] . ' ' . ( $end ?: '00:00' ), $tz );
+        $end_ts = $end_dt ? $end_dt->getTimestamp() : strtotime( $event['date'] . ' ' . ( $end ?: '00:00' ) );
+        if ( empty( $event['all_day_event'] ) && ( ! $end || $end_ts <= $start_ts ) ) {
+            $end_ts = $start_ts + HOUR_IN_SECONDS;
+        }
+
+        $event_permalink = $event['page_id'] ? get_permalink( intval( $event['page_id'] ) ) : '';
+        $description     = '';
+        if ( $event['page_id'] ) {
+            $description = TTA_Cache::remember( 'event_ics_desc_' . $event['page_id'], function() use ( $event ) {
+                $page_post = get_post( intval( $event['page_id'] ) );
+                if ( ! $page_post ) {
+                    return '';
+                }
+                return wp_trim_words( wp_strip_all_tags( $page_post->post_content ), 30, '…' );
+            }, 600 );
+        }
+
+        $details_parts = [];
+        if ( $description ) {
+            $details_parts[] = $description;
+        }
+        if ( $event_permalink ) {
+            $details_parts[] = $event_permalink;
+        }
+
+        $uid = sprintf( '%s@tryingtoadult', sanitize_key( $event['ute_id'] ?? uniqid( 'tta', true ) ) );
+        $now = gmdate( 'Ymd\THis\Z' );
+
+        $lines = [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'PRODID:-//Trying To Adult RVA//Event Calendar//EN',
+            'CALSCALE:GREGORIAN',
+            'METHOD:PUBLISH',
+            'BEGIN:VEVENT',
+            'UID:' . self::escape_ics_text( $uid ),
+            'DTSTAMP:' . $now,
+        ];
+
+        if ( ! empty( $event['all_day_event'] ) ) {
+            $lines[] = 'DTSTART;VALUE=DATE:' . gmdate( 'Ymd', $start_ts );
+            $lines[] = 'DTEND;VALUE=DATE:' . gmdate( 'Ymd', strtotime( '+1 day', $start_ts ) );
+        } else {
+            $lines[] = 'DTSTART:' . gmdate( 'Ymd\THis\Z', $start_ts );
+            $lines[] = 'DTEND:' . gmdate( 'Ymd\THis\Z', $end_ts );
+        }
+
+        $lines[] = 'SUMMARY:' . self::escape_ics_text( $event['name'] ?? '' );
+        if ( $formatted_address ) {
+            $lines[] = 'LOCATION:' . self::escape_ics_text( $formatted_address );
+        }
+        if ( $details_parts ) {
+            $lines[] = 'DESCRIPTION:' . self::escape_ics_text( implode( "\n\n", $details_parts ) );
+        }
+        if ( $event_permalink ) {
+            $lines[] = 'URL:' . self::escape_ics_text( $event_permalink );
+        }
+        $lines[] = 'END:VEVENT';
+        $lines[] = 'END:VCALENDAR';
+
+        $content  = implode( "\r\n", $lines ) . "\r\n";
+        $filename = sprintf( 'tta-event-%s.ics', sanitize_file_name( $event['name'] ?? $event['ute_id'] ?? 'event' ) );
+
+        nocache_headers();
+        header( 'Content-Type: text/calendar; charset=utf-8' );
+        header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
+        header( 'Content-Length: ' . strlen( $content ) );
+
+        echo $content;
+        exit;
+    }
+
+    private static function escape_ics_text( $text ) {
+        $text = (string) $text;
+        $text = str_replace( "\\", "\\\\", $text );
+        $text = str_replace( ";", "\\;", $text );
+        $text = str_replace( ",", "\\,", $text );
+        $text = str_replace( [ "\r\n", "\n", "\r" ], "\\n", $text );
+        return $text;
+    }
+}
+
+TTA_Event_ICS_Download::init();

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -1163,6 +1163,14 @@ echo '<div id="tta-login-wrap">' . $form_html . $lost_pw_html . '</div>';
               </a>
             </div>
           </li>
+          <li>
+            <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/ics-calendar.svg' ); ?>" alt="<?php echo esc_attr__( 'Calendar File Download', 'tta' ); ?>">
+            <div class="tta-event-details-icon-after">
+              <a style="font-weight:bold;" href="<?php echo esc_url( '#' ); ?>" target="_blank" rel="noopener">
+                <?php esc_html_e( 'Other Calendars (File Download)', 'tta' ); ?>
+              </a>
+            </div>
+          </li>
           <li class="tta-event-map-embed">
             <iframe
               width="100%" height="200" frameborder="0" style="border:0"

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -419,6 +419,37 @@ if ( $raw_content ) {
 }
 
 // ───────────────
+// 9c) Build Google Calendar link
+// ───────────────
+$calendar_end_ts = $end_ts;
+if ( ! $event['all_day_event'] && ( ! $end || $end_ts <= $start_ts ) ) {
+    $calendar_end_ts = $start_ts + HOUR_IN_SECONDS;
+}
+$google_calendar_dates = $event['all_day_event']
+    ? gmdate( 'Ymd', $start_ts ) . '/' . gmdate( 'Ymd', strtotime( '+1 day', $start_ts ) )
+    : gmdate( 'Ymd\\THis\\Z', $start_ts ) . '/' . gmdate( 'Ymd\\THis\\Z', $calendar_end_ts );
+$event_permalink = get_permalink( $page_id );
+$details_parts   = [];
+if ( $description_excerpt ) {
+    $details_parts[] = $description_excerpt;
+}
+if ( $event_permalink ) {
+    $details_parts[] = $event_permalink;
+}
+$google_calendar_url = 'https://calendar.google.com/calendar/render?' . http_build_query(
+    [
+        'action'   => 'TEMPLATE',
+        'text'     => $event['name'],
+        'dates'    => $google_calendar_dates,
+        'details'  => implode( "\n\n", $details_parts ),
+        'location' => $formatted_address,
+    ],
+    '',
+    '&',
+    PHP_QUERY_RFC3986
+);
+
+// ───────────────
 // 10) Determine sidebar cost row
 // ───────────────
 if ( $ticket_count > 1 ) {
@@ -1121,6 +1152,15 @@ echo '<div id="tta-login-wrap">' . $form_html . $lost_pw_html . '</div>';
               <strong><?php esc_html_e( 'Location', 'tta' ); ?>:</strong>
               <a href="<?php echo esc_url( $map_url ); ?>" target="_blank" rel="noopener">
                 <?php echo esc_html( $formatted_address ); ?>
+              </a>
+            </div>
+          </li>
+          <li>
+            <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/googlecalendar.svg' ); ?>" alt="<?php echo esc_attr__( 'Google Calendar', 'tta' ); ?>">
+            <div class="tta-event-details-icon-after">
+              <strong><?php esc_html_e( 'Calendar', 'tta' ); ?>:</strong>
+              <a href="<?php echo esc_url( $google_calendar_url ); ?>" target="_blank" rel="noopener">
+                <?php esc_html_e( 'Add to Google Calendar', 'tta' ); ?>
               </a>
             </div>
           </li>

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -1158,8 +1158,7 @@ echo '<div id="tta-login-wrap">' . $form_html . $lost_pw_html . '</div>';
           <li>
             <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/googlecalendar.svg' ); ?>" alt="<?php echo esc_attr__( 'Google Calendar', 'tta' ); ?>">
             <div class="tta-event-details-icon-after">
-              <strong><?php esc_html_e( 'Calendar', 'tta' ); ?>:</strong>
-              <a href="<?php echo esc_url( $google_calendar_url ); ?>" target="_blank" rel="noopener">
+              <a style="font-weight:bold;" href="<?php echo esc_url( $google_calendar_url ); ?>" target="_blank" rel="noopener">
                 <?php esc_html_e( 'Add to Google Calendar', 'tta' ); ?>
               </a>
             </div>

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -448,6 +448,13 @@ $google_calendar_url = 'https://calendar.google.com/calendar/render?' . http_bui
     '&',
     PHP_QUERY_RFC3986
 );
+$ics_download_url = add_query_arg(
+    [
+        'tta_event_ics' => '1',
+        'event_ute_id'  => $event['ute_id'],
+    ],
+    home_url( '/' )
+);
 
 // ───────────────
 // 10) Determine sidebar cost row
@@ -1166,7 +1173,7 @@ echo '<div id="tta-login-wrap">' . $form_html . $lost_pw_html . '</div>';
           <li>
             <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/ics-calendar.svg' ); ?>" alt="<?php echo esc_attr__( 'Calendar File Download', 'tta' ); ?>">
             <div class="tta-event-details-icon-after">
-              <a style="font-weight:bold;" href="<?php echo esc_url( '#' ); ?>" target="_blank" rel="noopener">
+              <a style="font-weight:bold;" href="<?php echo esc_url( $ics_download_url ); ?>" target="_blank" rel="noopener">
                 <?php esc_html_e( 'Other Calendars (File Download)', 'tta' ); ?>
               </a>
             </div>

--- a/trying-to-adult-management-plugin.php
+++ b/trying-to-adult-management-plugin.php
@@ -243,6 +243,7 @@ spl_autoload_register( function ( $class ) {
 // Core includes
 require_once TTA_PLUGIN_DIR . 'includes/class-db-setup.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-event-page-manager.php';
+require_once TTA_PLUGIN_DIR . 'includes/frontend/class-event-ics-download.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-cart-page-manager.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-checkout-page-manager.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-events-list-page.php';


### PR DESCRIPTION
### Motivation

- Provide visitors an easy way to add an event to their Google Calendar directly from the Event Page sidebar. 
- Build the calendar link dynamically from the event data at render time so it is never stored in the database. 

### Description

- Compute event start/end timestamps and format Google Calendar `dates` (all-day and timed events) and build a `TEMPLATE` URL using `http_build_query` with `PHP_QUERY_RFC3986` in `includes/frontend/templates/event-page-template.php`.
- Insert a new sidebar list item that links to the generated Google Calendar URL and uses a new placeholder icon at `assets/images/public/event-page-icons/googlecalendar.svg`.
- Add a minimal SVG placeholder file at `assets/images/public/event-page-icons/googlecalendar.svg` and update documentation in `docs/EventPage.md` to mention the new Calendar link.

### Testing

- No automated tests were executed for this change (no `phpunit`/CI run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69653e2a252c832093a953975ccfecc8)