### PR TITLE
Log membership level changes in member history

### DIFF
--- a/docs/MemberHistoryAdmin.md
+++ b/docs/MemberHistoryAdmin.md
@@ -15,6 +15,8 @@ An **Export Members** form lets administrators download a spreadsheet with the s
 - A complete payment history table including event purchases and membership charges
 - Event History table listing each event the member registered for with current attendance status and quick buttons to mark them as **Attended** or **No Show**
 - Membership cancellation entries noting who performed the action and the last four digits of the card
+- Membership start entries noting the membership level, price, transaction ID, subscription ID (if known), and timestamp
+- Membership change entries noting previous level, new level, price, who changed it, and timestamp
 - Any private notes stored with the member record appear in the expanded detail view rather than as a table column
 
 The summary metrics, member email and notes appear as columns in a single-row `widefat` table above the payment history for quick reference. The “Member Summary” heading also includes a tooltip describing the data shown.

--- a/includes/ajax/handlers/class-ajax-membership-admin.php
+++ b/includes/ajax/handlers/class-ajax-membership-admin.php
@@ -235,7 +235,9 @@ class TTA_Ajax_Membership_Admin {
             wp_send_json_error( [ 'message' => $res['error'] ] );
         }
 
+        $previous_level = strtolower( $member['membership_level'] ?? 'free' );
         tta_update_user_membership_level( $member['wpuserid'], $level );
+        tta_log_membership_change( $member['wpuserid'], $previous_level, $level, $amount, 'admin' );
         TTA_Cache::flush();
 
         wp_send_json_success( [ 'message' => __( 'Membership updated.', 'tta' ) ] );

--- a/includes/ajax/handlers/class-ajax-membership.php
+++ b/includes/ajax/handlers/class-ajax-membership.php
@@ -115,6 +115,7 @@ class TTA_Ajax_Membership {
         }
 
         tta_update_user_membership_level( $user_id, $level );
+        tta_log_membership_change( $user_id, $current, $level, $amount, 'member' );
         TTA_Cache::flush();
         TTA_Email_Handler::get_instance()->send_membership_change_email( $user_id, $level );
 
@@ -235,4 +236,3 @@ class TTA_Ajax_Membership {
 }
 
 TTA_Ajax_Membership::init();
-


### PR DESCRIPTION
### Motivation
- Ensure membership level updates are recorded in `tta_memberhistory` so admins and members can see when a level change occurred and relevant details.
- Capture full date/time, previous level, new level, price, and actor (member/admin) for each change.
- Follow the existing history insert patterns and cache invalidation used elsewhere (for example `tta_log_membership_cancellation`) to keep the billing/history views consistent.

### Description
- Added a helper `tta_log_membership_change()` in `includes/helpers.php` that inserts a `membership_change` row into `tta_memberhistory` with `occurred_at`, `previous_level`, `new_level`, `price`, and `by`, and invalidates the billing history cache via `TTA_Cache::delete`.
- Logged member-initiated level updates by calling `tta_log_membership_change()` in the frontend handler `includes/ajax/handlers/class-ajax-membership.php::ajax_change_membership_level` with actor `'member'` and the resolved price.
- Logged admin-initiated level updates by calling `tta_log_membership_change()` in the admin handler `includes/ajax/handlers/class-ajax-membership-admin.php::change_level` with actor `'admin'` and the resolved previous level and price.
- Documented the new membership change entries in `docs/MemberHistoryAdmin.md` so the admin UI expectations reflect the new history rows.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ba83eea388320a510a17727ca75dd)