### PR TITLE
Add membership Monthly Overview to BI dashboard and member history logging

### DIFF
--- a/docs/BIDashboard.md
+++ b/docs/BIDashboard.md
@@ -1,26 +1,28 @@
 # TTA BI Dashboard
 
-The **TTA BI Dashboard** appears as its own menu item in the WordPress admin and surfaces business intelligence metrics for managers. Data is fetched via the `tta_bi_data` AJAX action and rendered with D3.js. Charts are organised into **Event Sales & Tickets**, **Membership Metrics** and **Predictive Analytics** tabs. Most charts include timeframe selectors for the last month, last 3 months, 6, 12 or 24 months. The predictive tab instead offers forecasts 1 week, 1 month, 3 months or 6 months into the future. Changing a selector reloads only that chart without a full page refresh. Optional *Compare previous period* checkboxes overlay data from the prior timeframe. Charts feature hover tooltips displaying numbers and dollar amounts with helpful grid lines and animations.
+The **TTA BI Dashboard** appears as its own menu item in the WordPress admin and surfaces business intelligence metrics for managers. Data is fetched via the `tta_bi_data` AJAX action and rendered with D3.js. Charts are organised into **Event Sales & Tickets**, **Membership Metrics** and **Predictive Analytics** tabs. Most charts include timeframe selectors for the last month, last 3 months, 6, 12 or 24 months. The predictive tab instead offers forecasts 1 week, 1 month, 3 months or 6 months into the future. Changing a selector reloads only that chart without a full page refresh. Optional *Compare previous period* checkboxes overlay data from the prior timeframe. Charts feature hover tooltips displaying numbers and dollar amounts with helpful grid lines and animations. The Membership Metrics tab also includes a Monthly Overview table that summarizes totals, signups, cancellations, and estimated monthly revenue for each month in the selected range.
 
 ## Available Charts
 
 The dashboard now displays multiple sections:
 
-1. **Subscription Status** – bar chart of active, cancelled and payment-problem subscriptions.
-2. **New Member Signups** – line chart showing signups per month for the selected timeframe.
-3. **Monthly Revenue** – line chart of total revenue from all transactions for the chosen period.
-4. **Ticket Sales Per Year** – bar chart summarising yearly event revenue.
-5. **Average Tickets per Event** – monthly average tickets sold per event for the current year.
-6. **Cumulative Revenue** – running total of all revenue for the selected period.
-7. **Membership Levels** – pie chart of members by current level.
-8. **Monthly Churn Rate** – percentage of members who cancelled each month.
-9. **Predicted Revenue** – simple forecast for next month based on the recent average.
+1. **Monthly Overview** – table summarizing membership totals, signups, cancellations, and estimated monthly revenue.
+2. **Subscription Status** – bar chart of active, cancelled and payment-problem subscriptions.
+3. **New Member Signups** – line chart showing signups per month for the selected timeframe.
+4. **Monthly Revenue** – line chart of total revenue from all transactions for the chosen period.
+5. **Ticket Sales Per Year** – bar chart summarising yearly event revenue.
+6. **Average Tickets per Event** – monthly average tickets sold per event for the current year.
+7. **Cumulative Revenue** – running total of all revenue for the selected period.
+8. **Membership Levels** – pie chart of members by current level.
+9. **Monthly Churn Rate** – percentage of members who cancelled each month.
+10. **Predicted Revenue** – simple forecast for next month based on the recent average.
 
 The AJAX response includes arrays for each dataset:
 
 ```json
 {
   "subs": [{"label":"Active","count":10}],
+  "members_overview": [{"label":"2025-01","total_members":120,"standard_members":80,"premium_members":40,"signups":10,"cancellations":2,"estimated_revenue":1510}],
   "signups": [{"label":"Jul","count":5}],
   "revenue": [{"label":"2025-01","amount":1200}],
   "ticket_sales": [{"label":"2025","amount":5000}],

--- a/docs/MemberHistoryAdmin.md
+++ b/docs/MemberHistoryAdmin.md
@@ -15,6 +15,8 @@ An **Export Members** form lets administrators download a spreadsheet with the s
 - A complete payment history table including event purchases and membership charges
 - Event History table listing each event the member registered for with current attendance status and quick buttons to mark them as **Attended** or **No Show**
 - Membership cancellation entries noting who performed the action and the last four digits of the card
+- Membership start entries noting the membership level, price, transaction ID, subscription ID (if known), and timestamp
+- Membership change entries noting previous level, new level, price, who changed it, and timestamp
 - Any private notes stored with the member record appear in the expanded detail view rather than as a table column
 
 The summary metrics, member email and notes appear as columns in a single-row `widefat` table above the payment history for quick reference. The “Member Summary” heading also includes a tooltip describing the data shown.

--- a/includes/admin/views/bi-dashboard.php
+++ b/includes/admin/views/bi-dashboard.php
@@ -2,6 +2,21 @@
 <div id="tta-bi-dashboard" class="wrap">
 <?php if ( $tab === 'members' ) : ?>
   <section class="tta-bi-section">
+    <h2>Monthly Overview</h2>
+    <label>Timeframe:
+      <select class="tta-bi-range" data-chart="members_overview">
+        <option value="1">Last month</option>
+        <option value="3">Last 3 months</option>
+        <option value="6">Last 6 months</option>
+        <option value="12">Last 12 months</option>
+        <option value="24">Last 24 months</option>
+      </select>
+    </label>
+    <p>Summary of member totals, signups, cancellations, and estimated monthly revenue.</p>
+    <div id="tta-bi-members-overview" class="tta-bi-chart"></div>
+  </section>
+
+  <section class="tta-bi-section">
     <h2>Subscription Status</h2>
     <label>Timeframe:
       <select class="tta-bi-range" data-chart="subs">
@@ -147,7 +162,7 @@
 (function(){
   const selects=document.querySelectorAll('.tta-bi-range');
   const compares=document.querySelectorAll('.tta-bi-compare input');
-  const map={subs:'#tta-bi-subscription-chart',signups:'#tta-bi-signups-chart',revenue:'#tta-bi-revenue-chart',cumulative:'#tta-bi-cumulative',ticket_sales:'#tta-bi-ticket-sales',avg_tickets:'#tta-bi-avg-tickets',by_level:'#tta-bi-by-level',churn:'#tta-bi-churn',prediction:'#tta-bi-prediction'};
+  const map={members_overview:'#tta-bi-members-overview',subs:'#tta-bi-subscription-chart',signups:'#tta-bi-signups-chart',revenue:'#tta-bi-revenue-chart',cumulative:'#tta-bi-cumulative',ticket_sales:'#tta-bi-ticket-sales',avg_tickets:'#tta-bi-avg-tickets',by_level:'#tta-bi-by-level',churn:'#tta-bi-churn',prediction:'#tta-bi-prediction'};
   const tooltip=d3.select('body').append('div').attr('class','tta-bi-tooltip').style('visibility','hidden');
   const valFmt=v=>'$'+(+v).toLocaleString(undefined,{minimumFractionDigits:2,maximumFractionDigits:2});
 
@@ -165,6 +180,7 @@
     if(!sel)return;
     document.querySelector(sel).innerHTML='';
     switch(chart){
+      case 'members_overview': renderOverview(sel, data.members_overview); break;
       case 'subs': renderBar(sel, data.subs, 'count','Subscriptions'); break;
       case 'signups': renderLine(sel, data.signups,'count','Signups', data.signups_prev); break;
       case 'revenue': renderLine(sel, data.revenue,'amount','Revenue', data.revenue_prev); break;
@@ -183,6 +199,39 @@
     const sel=document.querySelector(`select[data-chart="${chart}"]`);
     if(sel) load(sel);
   }));
+
+  function renderOverview(sel, d){
+    if (!d || !d.length) {
+      return;
+    }
+    const table=document.createElement('table');
+    table.className='widefat striped';
+    table.innerHTML=
+      '<thead><tr>'+
+      '<th>Month</th>'+
+      '<th>Total Members</th>'+
+      '<th>Standard Members</th>'+
+      '<th>Premium Members</th>'+
+      '<th>Signups</th>'+
+      '<th>Cancellations</th>'+
+      '<th>Estimated Monthly Revenue</th>'+
+      '</tr></thead>';
+    const tbody=document.createElement('tbody');
+    d.forEach(row=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML=
+        `<td>${row.label}</td>`+
+        `<td>${row.total_members}</td>`+
+        `<td>${row.standard_members}</td>`+
+        `<td>${row.premium_members}</td>`+
+        `<td>${row.signups}</td>`+
+        `<td>${row.cancellations}</td>`+
+        `<td>${valFmt(row.estimated_revenue)}</td>`;
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    document.querySelector(sel).appendChild(table);
+  }
 
   function renderBar(sel,d,val,label){
     const svg=d3.select(sel).append('svg').attr('width',620).attr('height',320);

--- a/includes/ajax/handlers/class-ajax-membership-admin.php
+++ b/includes/ajax/handlers/class-ajax-membership-admin.php
@@ -235,7 +235,9 @@ class TTA_Ajax_Membership_Admin {
             wp_send_json_error( [ 'message' => $res['error'] ] );
         }
 
+        $previous_level = strtolower( $member['membership_level'] ?? 'free' );
         tta_update_user_membership_level( $member['wpuserid'], $level );
+        tta_log_membership_change( $member['wpuserid'], $previous_level, $level, $amount, 'admin' );
         TTA_Cache::flush();
 
         wp_send_json_success( [ 'message' => __( 'Membership updated.', 'tta' ) ] );

--- a/includes/ajax/handlers/class-ajax-membership.php
+++ b/includes/ajax/handlers/class-ajax-membership.php
@@ -115,6 +115,7 @@ class TTA_Ajax_Membership {
         }
 
         tta_update_user_membership_level( $user_id, $level );
+        tta_log_membership_change( $user_id, $current, $level, $amount, 'member' );
         TTA_Cache::flush();
         TTA_Email_Handler::get_instance()->send_membership_change_email( $user_id, $level );
 
@@ -235,4 +236,3 @@ class TTA_Ajax_Membership {
 }
 
 TTA_Ajax_Membership::init();
-


### PR DESCRIPTION
### Motivation
- Provide a Monthly Overview in the Membership Metrics tab so managers can see per-month totals, signups, cancellations and an estimated monthly revenue figure derived from active paying members. 
- Surface membership lifecycle events in `tta_memberhistory` (starts and level changes) so BI and admin views can reference accurate membership activity and payments.

### Description
- Added a new Monthly Overview section and selector to the Membership Metrics view and client script (`includes/admin/views/bi-dashboard.php`) and implemented `renderOverview` to show a `widefat` table for the dataset. 
- Extended the BI AJAX handler (`includes/ajax/handlers/class-ajax-bi.php`) to return a `members_overview` dataset (cached via `TTA_Cache`) that computes per-month `total_members`, `standard_members`, `premium_members`, `signups`, `cancellations`, and `estimated_revenue` using DB queries and membership price constants. 
- Added helper functions to `includes/helpers.php`: `tta_normalize_membership_level_from_label`, `tta_log_membership_start_from_purchase` (hooked to `tta_after_purchase_logged`), and `tta_log_membership_change` to record `membership_start` and `membership_change` rows in `tta_memberhistory` and clear relevant caches. 
- Logged level changes from both the admin and frontend handlers by calling `tta_log_membership_change` in `includes/ajax/handlers/class-ajax-membership-admin.php` and `includes/ajax/handlers/class-ajax-membership.php`. 
- Updated documentation (`docs/BIDashboard.md` and `docs/MemberHistoryAdmin.md`) to describe the new Monthly Overview dataset and the added member-history entry types.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ba83eea388320a510a17727ca75dd)