### PR TITLE
Add Membership Monthly Overview to BI Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Most development work happens inside the plugin located at:
 
 `app/public/wp-content/plugins/tta-management-plugin`
 
-Current plugin version: **1.0.8**
+Current plugin version: **1.0.9**
 
 - Unless a task explicitly states otherwise, assume questions and changes refer to this plugin.
 - The plugin must remain self-contained so it can be copied to another WordPress installation and function on its own.
@@ -22,4 +22,3 @@ cd app/public/wp-content/plugins/tta-management-plugin
 composer install
 vendor/bin/phpunit
 ```
-

--- a/assets/css/backend/admin.css
+++ b/assets/css/backend/admin.css
@@ -305,6 +305,10 @@ form p.submit{
   font-size: 18px;
 }
 
+#tta-bi-dashboard .tta-bi-members-monthly-overview__value {
+  font-size: 18px;
+}
+
 #tta-bi-dashboard .tta-bi-month-selector {
   text-align: center;
   margin-bottom: 20px;

--- a/assets/js/backend/admin.js
+++ b/assets/js/backend/admin.js
@@ -488,7 +488,7 @@ jQuery(function($){
         return;
       }
       var metrics = res.data.metrics;
-      $('.tta-bi-members-monthly-overview__value').each(function(){
+      $('.tta-bi-members-monthly-overview .tta-bi-members-monthly-overview__value').each(function(){
         var key = $(this).data('metric');
         if (metrics[key] !== undefined) {
           $(this).text(metrics[key]);

--- a/assets/js/backend/admin.js
+++ b/assets/js/backend/admin.js
@@ -566,6 +566,65 @@ jQuery(function($){
     });
   });
 
+  //
+  // BI Dashboard: membership comparison toggle and selector
+  //
+  $(document).on('change', '#tta-bi-members-compare-toggle', function(){
+    var $toggle = $(this);
+    var isChecked = $toggle.is(':checked');
+    var $selectWrap = $('.tta-bi-members-compare-select');
+    var $section = $('.tta-bi-members-compare-section');
+
+    $selectWrap.toggle(isChecked).attr('aria-hidden', !isChecked);
+    if (!isChecked) {
+      $section.removeClass('is-visible').attr('aria-hidden', true);
+      $('#tta-bi-members-compare-select').val('');
+    }
+  });
+
+  $(document).on('change', '#tta-bi-members-compare-select', function(){
+    var $select = $(this);
+    var comparison = $select.val();
+    if (!comparison) {
+      return;
+    }
+
+    var $spinner = $select.closest('.tta-bi-members-compare-select').find('.tta-admin-progress-spinner-svg');
+    $spinner.css({ opacity: 1, display: 'inline-block' });
+
+    $.post(TTA_Ajax.ajax_url, {
+      action: 'tta_bi_members_comparison_overview',
+      nonce: TTA_Ajax.bi_members_comparison_overview_nonce,
+      comparison: comparison
+    }, function(res){
+      $spinner.fadeOut(200);
+      if (!res || !res.success || !res.data) {
+        return;
+      }
+
+      var previous = res.data.previous || {};
+      var current = res.data.current || {};
+      $('.tta-bi-members-compare-value').each(function(){
+        var key = $(this).data('metric');
+        var side = $(this).data('compare-side');
+        if (side === 'previous' && previous[key] !== undefined) {
+          $(this).text(previous[key]);
+        }
+        if (side === 'current' && current[key] !== undefined) {
+          $(this).text(current[key]);
+        }
+      });
+
+      var $columns = $('.tta-bi-members-compare-section .tta-bi-members-compare-heading');
+      $columns.first().text(res.data.previous_label || 'Previous Period');
+      $columns.last().text(res.data.current_label || 'Current Period (to date)');
+
+      $('.tta-bi-members-compare-section').addClass('is-visible').attr('aria-hidden', false);
+    }, 'json').fail(function(){
+      $spinner.fadeOut(200);
+    });
+  });
+
   // Email Logs tab
   var $logs = $('#tta-email-logs');
   if ($logs.length) {

--- a/assets/js/backend/admin.js
+++ b/assets/js/backend/admin.js
@@ -494,6 +494,15 @@ jQuery(function($){
           $(this).text(metrics[key]);
         }
       });
+
+      var $selectedOption = $select.find('option:selected');
+      var monthName = $selectedOption.data('month-name');
+      if (!monthName) {
+        monthName = ($selectedOption.text() || '').trim().split(' ')[0];
+      }
+      if (monthName) {
+        $('.tta-bi-members-monthly-overview__title').text(monthName + ' Monthly Overview');
+      }
     }, 'json').fail(function(){
       $spinner.fadeOut(200);
     });

--- a/assets/js/backend/admin.js
+++ b/assets/js/backend/admin.js
@@ -466,6 +466,40 @@ jQuery(function($){
   });
 
   //
+  // BI Dashboard: membership monthly overview selector
+  //
+  $(document).on('change', '#tta-bi-members-month-selector', function(){
+    var $select = $(this);
+    var month = $select.val();
+    if (!month) {
+      return;
+    }
+
+    var $spinner = $select.closest('.tta-bi-month-selector').find('.tta-admin-progress-spinner-svg');
+    $spinner.css({ opacity: 1, display: 'inline-block' });
+
+    $.post(TTA_Ajax.ajax_url, {
+      action: 'tta_bi_members_monthly_overview',
+      nonce: TTA_Ajax.bi_members_monthly_overview_nonce,
+      month: month
+    }, function(res){
+      $spinner.fadeOut(200);
+      if (!res || !res.success || !res.data || !res.data.metrics) {
+        return;
+      }
+      var metrics = res.data.metrics;
+      $('.tta-bi-members-monthly-overview__value').each(function(){
+        var key = $(this).data('metric');
+        if (metrics[key] !== undefined) {
+          $(this).text(metrics[key]);
+        }
+      });
+    }, 'json').fail(function(){
+      $spinner.fadeOut(200);
+    });
+  });
+
+  //
   // BI Dashboard: comparison toggle and selector
   //
   $(document).on('change', '#tta-bi-compare-toggle', function(){

--- a/docs/BIDashboard.md
+++ b/docs/BIDashboard.md
@@ -1,11 +1,9 @@
 # TTA BI Dashboard
 
-The **TTA BI Dashboard** appears as its own menu item in the WordPress admin. The existing Events, Members, and Predictive Analytics tabs have been intentionally cleared so the dashboards can be redesigned from scratch. The tabs remain visible, but they currently display placeholder messaging only.
+The **TTA BI Dashboard** appears as its own menu item in the WordPress admin. The existing Events and Members tabs have been intentionally cleared so the dashboards can be redesigned from scratch. The tabs remain visible, but they currently display placeholder messaging only.
 
 ## Current State
 
 - **Event Revenue Info tab**: Lists archived events with a basic search/sort header and pagination. Rows expand accordion-style to show attendance and revenue metrics, including total signups, total attended, standard/premium member attendance (based on member records as of the event date), gross ticket sales, refunds issued, and net profit. A Monthly Overview section above the search controls aggregates the selected month’s totals across archived events, with a month selector that updates via AJAX. A comparison toggle can show side-by-side totals for the last month/quarter/year versus the current period to date.
 - **Members tab**: Current Membership Metrics (totals and estimated monthly recurring revenue) plus a month-labeled Monthly Overview (signups, standard signups, premium signups, and cancellations). The month selector defaults to the current month and updates only the Monthly Overview via AJAX; all metrics are cached for performance. A comparison toggle mirrors the Events tab behavior to compare membership metrics across standard periods.
-- **Predictive Analytics tab**: Placeholder only while new UI and data logic are rebuilt.
-
 No charting scripts are active for the dashboard at this time. New data sources, caching, and visualizations should be documented here as soon as the rebuild work begins.

--- a/docs/BIDashboard.md
+++ b/docs/BIDashboard.md
@@ -5,7 +5,7 @@ The **TTA BI Dashboard** appears as its own menu item in the WordPress admin. Th
 ## Current State
 
 - **Event Revenue Info tab**: Lists archived events with a basic search/sort header and pagination. Rows expand accordion-style to show attendance and revenue metrics, including total signups, total attended, standard/premium member attendance (based on member records as of the event date), gross ticket sales, refunds issued, and net profit. A Monthly Overview section above the search controls aggregates the selected month’s totals across archived events, with a month selector that updates via AJAX. A comparison toggle can show side-by-side totals for the last month/quarter/year versus the current period to date.
-- **Members tab**: Member Metrics (totals and estimated monthly recurring revenue) plus a Monthly Overview (signups and cancellations). Metrics are calculated from the members and member history tables, with month selection handled via AJAX and cached for performance.
+- **Members tab**: Current month Membership Metrics (totals and estimated monthly recurring revenue) plus a Monthly Overview (signups, standard signups, premium signups, and cancellations). Metrics are calculated from the members and member history tables, with month selection handled via AJAX and cached for performance.
 - **Predictive Analytics tab**: Placeholder only while new UI and data logic are rebuilt.
 
 No charting scripts are active for the dashboard at this time. New data sources, caching, and visualizations should be documented here as soon as the rebuild work begins.

--- a/docs/BIDashboard.md
+++ b/docs/BIDashboard.md
@@ -5,7 +5,7 @@ The **TTA BI Dashboard** appears as its own menu item in the WordPress admin. Th
 ## Current State
 
 - **Event Revenue Info tab**: Lists archived events with a basic search/sort header and pagination. Rows expand accordion-style to show attendance and revenue metrics, including total signups, total attended, standard/premium member attendance (based on member records as of the event date), gross ticket sales, refunds issued, and net profit. A Monthly Overview section above the search controls aggregates the selected month’s totals across archived events, with a month selector that updates via AJAX. A comparison toggle can show side-by-side totals for the last month/quarter/year versus the current period to date.
-- **Members tab**: Placeholder only while new UI and data logic are rebuilt.
+- **Members tab**: Monthly Overview for membership metrics (total members, standard members, premium members, signups, cancellations, and estimated monthly recurring revenue). Metrics are calculated from the members and member history tables, with month selection handled via AJAX and cached for performance.
 - **Predictive Analytics tab**: Placeholder only while new UI and data logic are rebuilt.
 
-No charting scripts or AJAX handlers are active for the dashboard at this time. New data sources, caching, and visualizations should be documented here as soon as the rebuild work begins.
+No charting scripts are active for the dashboard at this time. New data sources, caching, and visualizations should be documented here as soon as the rebuild work begins.

--- a/docs/BIDashboard.md
+++ b/docs/BIDashboard.md
@@ -5,7 +5,7 @@ The **TTA BI Dashboard** appears as its own menu item in the WordPress admin. Th
 ## Current State
 
 - **Event Revenue Info tab**: Lists archived events with a basic search/sort header and pagination. Rows expand accordion-style to show attendance and revenue metrics, including total signups, total attended, standard/premium member attendance (based on member records as of the event date), gross ticket sales, refunds issued, and net profit. A Monthly Overview section above the search controls aggregates the selected month’s totals across archived events, with a month selector that updates via AJAX. A comparison toggle can show side-by-side totals for the last month/quarter/year versus the current period to date.
-- **Members tab**: Current Membership Metrics (totals and estimated monthly recurring revenue) plus a month-labeled Monthly Overview (signups, standard signups, premium signups, and cancellations). The month selector defaults to the current month and updates only the Monthly Overview via AJAX; all metrics are cached for performance.
+- **Members tab**: Current Membership Metrics (totals and estimated monthly recurring revenue) plus a month-labeled Monthly Overview (signups, standard signups, premium signups, and cancellations). The month selector defaults to the current month and updates only the Monthly Overview via AJAX; all metrics are cached for performance. A comparison toggle mirrors the Events tab behavior to compare membership metrics across standard periods.
 - **Predictive Analytics tab**: Placeholder only while new UI and data logic are rebuilt.
 
 No charting scripts are active for the dashboard at this time. New data sources, caching, and visualizations should be documented here as soon as the rebuild work begins.

--- a/docs/BIDashboard.md
+++ b/docs/BIDashboard.md
@@ -5,7 +5,7 @@ The **TTA BI Dashboard** appears as its own menu item in the WordPress admin. Th
 ## Current State
 
 - **Event Revenue Info tab**: Lists archived events with a basic search/sort header and pagination. Rows expand accordion-style to show attendance and revenue metrics, including total signups, total attended, standard/premium member attendance (based on member records as of the event date), gross ticket sales, refunds issued, and net profit. A Monthly Overview section above the search controls aggregates the selected month’s totals across archived events, with a month selector that updates via AJAX. A comparison toggle can show side-by-side totals for the last month/quarter/year versus the current period to date.
-- **Members tab**: Monthly Overview for membership metrics (total members, standard members, premium members, signups, cancellations, and estimated monthly recurring revenue). Metrics are calculated from the members and member history tables, with month selection handled via AJAX and cached for performance.
+- **Members tab**: Member Metrics (totals and estimated monthly recurring revenue) plus a Monthly Overview (signups and cancellations). Metrics are calculated from the members and member history tables, with month selection handled via AJAX and cached for performance.
 - **Predictive Analytics tab**: Placeholder only while new UI and data logic are rebuilt.
 
 No charting scripts are active for the dashboard at this time. New data sources, caching, and visualizations should be documented here as soon as the rebuild work begins.

--- a/docs/BIDashboard.md
+++ b/docs/BIDashboard.md
@@ -5,7 +5,7 @@ The **TTA BI Dashboard** appears as its own menu item in the WordPress admin. Th
 ## Current State
 
 - **Event Revenue Info tab**: Lists archived events with a basic search/sort header and pagination. Rows expand accordion-style to show attendance and revenue metrics, including total signups, total attended, standard/premium member attendance (based on member records as of the event date), gross ticket sales, refunds issued, and net profit. A Monthly Overview section above the search controls aggregates the selected month’s totals across archived events, with a month selector that updates via AJAX. A comparison toggle can show side-by-side totals for the last month/quarter/year versus the current period to date.
-- **Members tab**: Current month Membership Metrics (totals and estimated monthly recurring revenue) plus a Monthly Overview (signups, standard signups, premium signups, and cancellations). Metrics are calculated from the members and member history tables, with month selection handled via AJAX and cached for performance.
+- **Members tab**: Current Membership Metrics (totals and estimated monthly recurring revenue) plus a month-labeled Monthly Overview (signups, standard signups, premium signups, and cancellations). The month selector defaults to the current month and updates only the Monthly Overview via AJAX; all metrics are cached for performance.
 - **Predictive Analytics tab**: Placeholder only while new UI and data logic are rebuilt.
 
 No charting scripts are active for the dashboard at this time. New data sources, caching, and visualizations should be documented here as soon as the rebuild work begins.

--- a/includes/admin/class-bi-admin.php
+++ b/includes/admin/class-bi-admin.php
@@ -25,7 +25,6 @@ class TTA_BI_Admin {
         $tabs = [
             'events'   => 'Event Revenue Info',
             'members'  => 'Membership Metrics',
-            'predict'  => 'Predictive Analytics',
         ];
 
         echo '<div class="wrap"><h1>TTA BI Dashboard</h1><h2 class="nav-tab-wrapper">';

--- a/includes/admin/views/bi-dashboard.php
+++ b/includes/admin/views/bi-dashboard.php
@@ -3,7 +3,6 @@ $tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'events';
 $tab_labels = [
     'events'  => 'Event Revenue Info',
     'members' => 'Members',
-    'predict' => 'Predictive Analytics',
 ];
 $tab_title = isset( $tab_labels[ $tab ] ) ? $tab_labels[ $tab ] : $tab_labels['events'];
 ?>

--- a/includes/admin/views/bi-dashboard.php
+++ b/includes/admin/views/bi-dashboard.php
@@ -554,18 +554,9 @@ $tab_title = isset( $tab_labels[ $tab ] ) ? $tab_labels[ $tab ] : $tab_labels['e
         ?>
 
         <?php $current_month_name = date_i18n( 'F', current_time( 'timestamp' ) ); ?>
+        <?php $current_month_overview_title = sprintf( __( '%s Monthly Overview', 'tta' ), $current_month_name ); ?>
         <div class="tta-bi-monthly-overview tta-bi-members-metrics">
-            <h3>
-                <?php
-                echo esc_html(
-                    sprintf(
-                        /* translators: %s is the current month name. */
-                        __( 'Current %s Membership Metrics', 'tta' ),
-                        $current_month_name
-                    )
-                );
-                ?>
-            </h3>
+            <h3><?php esc_html_e( 'Current Membership Metrics', 'tta' ); ?></h3>
             <div class="tta-bi-monthly-overview__stats">
                 <div class="tta-bi-monthly-overview__stat">
                     <span class="tta-bi-monthly-overview__label"><?php esc_html_e( 'Total Number of Members', 'tta' ); ?></span>
@@ -587,7 +578,7 @@ $tab_title = isset( $tab_labels[ $tab ] ) ? $tab_labels[ $tab ] : $tab_labels['e
         </div>
 
         <div class="tta-bi-monthly-overview tta-bi-members-monthly-overview">
-            <h3><?php esc_html_e( 'Monthly Overview', 'tta' ); ?></h3>
+            <h3 class="tta-bi-members-monthly-overview__title"><?php echo esc_html( $current_month_overview_title ); ?></h3>
             <div class="tta-bi-monthly-overview__stats">
                 <div class="tta-bi-monthly-overview__stat">
                     <span class="tta-bi-monthly-overview__label"><?php esc_html_e( 'Total Number of Signups', 'tta' ); ?></span>
@@ -611,9 +602,12 @@ $tab_title = isset( $tab_labels[ $tab ] ) ? $tab_labels[ $tab ] : $tab_labels['e
         <div class="tta-bi-month-selector">
             <label for="tta-bi-members-month-selector" class="screen-reader-text"><?php esc_html_e( 'Select a Month', 'tta' ); ?></label>
             <select id="tta-bi-members-month-selector">
-                <option value="" disabled selected><?php esc_html_e( 'Select a Month...', 'tta' ); ?></option>
+                <option value="" disabled><?php esc_html_e( 'Select a Month...', 'tta' ); ?></option>
                 <?php foreach ( $available_months as $month ) : ?>
-                    <option value="<?php echo esc_attr( $month ); ?>"><?php echo esc_html( date_i18n( 'F Y', strtotime( $month . '-01' ) ) ); ?></option>
+                    <?php $month_name = date_i18n( 'F', strtotime( $month . '-01' ) ); ?>
+                    <option value="<?php echo esc_attr( $month ); ?>" data-month-name="<?php echo esc_attr( $month_name ); ?>" <?php selected( $month, $current_month ); ?>>
+                        <?php echo esc_html( date_i18n( 'F Y', strtotime( $month . '-01' ) ) ); ?>
+                    </option>
                 <?php endforeach; ?>
             </select>
             <div class="tta-admin-progress-spinner-div">

--- a/includes/admin/views/bi-dashboard.php
+++ b/includes/admin/views/bi-dashboard.php
@@ -554,7 +554,7 @@ $tab_title = isset( $tab_labels[ $tab ] ) ? $tab_labels[ $tab ] : $tab_labels['e
         ?>
 
         <div class="tta-bi-monthly-overview">
-            <h3><?php esc_html_e( 'Monthly Overview', 'tta' ); ?></h3>
+            <h3><?php esc_html_e( 'Member Metrics', 'tta' ); ?></h3>
             <div class="tta-bi-monthly-overview__stats">
                 <div class="tta-bi-monthly-overview__stat">
                     <span class="tta-bi-monthly-overview__label"><?php esc_html_e( 'Total Number of Members', 'tta' ); ?></span>
@@ -569,16 +569,22 @@ $tab_title = isset( $tab_labels[ $tab ] ) ? $tab_labels[ $tab ] : $tab_labels['e
                     <span class="tta-bi-members-monthly-overview__value" data-metric="total_premium"><?php echo esc_html( $monthly_metrics_display['total_premium'] ); ?></span>
                 </div>
                 <div class="tta-bi-monthly-overview__stat">
+                    <span class="tta-bi-monthly-overview__label"><?php esc_html_e( 'Total Estimated Monthly Revenue', 'tta' ); ?></span>
+                    <span class="tta-bi-members-monthly-overview__value" data-metric="total_estimated_revenue"><?php echo esc_html( $monthly_metrics_display['total_estimated_revenue'] ); ?></span>
+                </div>
+            </div>
+        </div>
+
+        <div class="tta-bi-monthly-overview">
+            <h3><?php esc_html_e( 'Monthly Overview', 'tta' ); ?></h3>
+            <div class="tta-bi-monthly-overview__stats">
+                <div class="tta-bi-monthly-overview__stat">
                     <span class="tta-bi-monthly-overview__label"><?php esc_html_e( 'Total Number of Signups', 'tta' ); ?></span>
                     <span class="tta-bi-members-monthly-overview__value" data-metric="total_signups"><?php echo esc_html( $monthly_metrics_display['total_signups'] ); ?></span>
                 </div>
                 <div class="tta-bi-monthly-overview__stat">
                     <span class="tta-bi-monthly-overview__label"><?php esc_html_e( 'Total Number of Cancellations', 'tta' ); ?></span>
                     <span class="tta-bi-members-monthly-overview__value" data-metric="total_cancellations"><?php echo esc_html( $monthly_metrics_display['total_cancellations'] ); ?></span>
-                </div>
-                <div class="tta-bi-monthly-overview__stat">
-                    <span class="tta-bi-monthly-overview__label"><?php esc_html_e( 'Total Estimated Monthly Revenue', 'tta' ); ?></span>
-                    <span class="tta-bi-members-monthly-overview__value" data-metric="total_estimated_revenue"><?php echo esc_html( $monthly_metrics_display['total_estimated_revenue'] ); ?></span>
                 </div>
             </div>
         </div>

--- a/includes/admin/views/bi-dashboard.php
+++ b/includes/admin/views/bi-dashboard.php
@@ -553,7 +553,7 @@ $tab_title = isset( $tab_labels[ $tab ] ) ? $tab_labels[ $tab ] : $tab_labels['e
         }
         ?>
 
-        <div class="tta-bi-monthly-overview">
+        <div class="tta-bi-monthly-overview tta-bi-members-metrics">
             <h3><?php esc_html_e( 'Member Metrics', 'tta' ); ?></h3>
             <div class="tta-bi-monthly-overview__stats">
                 <div class="tta-bi-monthly-overview__stat">
@@ -575,7 +575,7 @@ $tab_title = isset( $tab_labels[ $tab ] ) ? $tab_labels[ $tab ] : $tab_labels['e
             </div>
         </div>
 
-        <div class="tta-bi-monthly-overview">
+        <div class="tta-bi-monthly-overview tta-bi-members-monthly-overview">
             <h3><?php esc_html_e( 'Monthly Overview', 'tta' ); ?></h3>
             <div class="tta-bi-monthly-overview__stats">
                 <div class="tta-bi-monthly-overview__stat">

--- a/includes/admin/views/bi-dashboard.php
+++ b/includes/admin/views/bi-dashboard.php
@@ -614,6 +614,102 @@ $tab_title = isset( $tab_labels[ $tab ] ) ? $tab_labels[ $tab ] : $tab_labels['e
                 <img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" style="display:none; opacity:0;">
             </div>
         </div>
+
+        <div class="tta-bi-compare-toggle tta-bi-members-compare-toggle">
+            <label for="tta-bi-members-compare-toggle">
+                <input type="checkbox" id="tta-bi-members-compare-toggle">
+                <?php esc_html_e( 'Compare to...', 'tta' ); ?>
+            </label>
+        </div>
+
+        <div class="tta-bi-compare-select tta-bi-members-compare-select" aria-hidden="true">
+            <label for="tta-bi-members-compare-select" class="screen-reader-text"><?php esc_html_e( 'Select a Comparison Period', 'tta' ); ?></label>
+            <select id="tta-bi-members-compare-select">
+                <option value="" disabled selected><?php esc_html_e( 'Make a Selection...', 'tta' ); ?></option>
+                <option value="last_month"><?php esc_html_e( 'Month-To-Date', 'tta' ); ?></option>
+                <option value="last_quarter"><?php esc_html_e( 'Quarter-To-Date', 'tta' ); ?></option>
+                <option value="last_year"><?php esc_html_e( 'Year-To-Date', 'tta' ); ?></option>
+                <option value="last_30_days"><?php esc_html_e( 'Last 30 Days', 'tta' ); ?></option>
+                <option value="last_90_days"><?php esc_html_e( 'Last 90 Days', 'tta' ); ?></option>
+                <option value="last_365_days"><?php esc_html_e( 'Last 365 Days', 'tta' ); ?></option>
+            </select>
+            <div class="tta-admin-progress-spinner-div tta-bi-compare-spinner">
+                <img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="<?php esc_attr_e( 'Loading…', 'tta' ); ?>" style="display:none; opacity:0;">
+            </div>
+        </div>
+
+        <div class="tta-bi-compare-section tta-bi-members-compare-section" aria-hidden="true">
+            <div class="tta-bi-compare-column">
+                <h4 class="tta-bi-compare-heading tta-bi-members-compare-heading"><?php esc_html_e( 'Previous Period', 'tta' ); ?></h4>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Number of Members', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="previous" data-metric="total_members">—</span>
+                </div>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Number of Standard Members', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="previous" data-metric="total_standard">—</span>
+                </div>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Number of Premium Members', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="previous" data-metric="total_premium">—</span>
+                </div>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Number of Signups', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="previous" data-metric="total_signups">—</span>
+                </div>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Standard Member Signups', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="previous" data-metric="total_standard_signups">—</span>
+                </div>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Premium Member Signups', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="previous" data-metric="total_premium_signups">—</span>
+                </div>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Number of Cancellations', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="previous" data-metric="total_cancellations">—</span>
+                </div>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Estimated Monthly Revenue', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="previous" data-metric="total_estimated_revenue">—</span>
+                </div>
+            </div>
+            <div class="tta-bi-compare-column">
+                <h4 class="tta-bi-compare-heading tta-bi-members-compare-heading"><?php esc_html_e( 'Current Period (to date)', 'tta' ); ?></h4>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Number of Members', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="current" data-metric="total_members">—</span>
+                </div>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Number of Standard Members', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="current" data-metric="total_standard">—</span>
+                </div>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Number of Premium Members', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="current" data-metric="total_premium">—</span>
+                </div>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Number of Signups', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="current" data-metric="total_signups">—</span>
+                </div>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Standard Member Signups', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="current" data-metric="total_standard_signups">—</span>
+                </div>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Premium Member Signups', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="current" data-metric="total_premium_signups">—</span>
+                </div>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Number of Cancellations', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="current" data-metric="total_cancellations">—</span>
+                </div>
+                <div class="tta-bi-compare-stat">
+                    <span class="tta-bi-compare-label"><?php esc_html_e( 'Total Estimated Monthly Revenue', 'tta' ); ?></span>
+                    <span class="tta-bi-compare-value tta-bi-members-compare-value" data-compare-side="current" data-metric="total_estimated_revenue">—</span>
+                </div>
+            </div>
+        </div>
     <?php else : ?>
         <div class="notice notice-info">
             <p>

--- a/includes/admin/views/bi-dashboard.php
+++ b/includes/admin/views/bi-dashboard.php
@@ -553,8 +553,19 @@ $tab_title = isset( $tab_labels[ $tab ] ) ? $tab_labels[ $tab ] : $tab_labels['e
         }
         ?>
 
+        <?php $current_month_name = date_i18n( 'F', current_time( 'timestamp' ) ); ?>
         <div class="tta-bi-monthly-overview tta-bi-members-metrics">
-            <h3><?php esc_html_e( 'Member Metrics', 'tta' ); ?></h3>
+            <h3>
+                <?php
+                echo esc_html(
+                    sprintf(
+                        /* translators: %s is the current month name. */
+                        __( 'Current %s Membership Metrics', 'tta' ),
+                        $current_month_name
+                    )
+                );
+                ?>
+            </h3>
             <div class="tta-bi-monthly-overview__stats">
                 <div class="tta-bi-monthly-overview__stat">
                     <span class="tta-bi-monthly-overview__label"><?php esc_html_e( 'Total Number of Members', 'tta' ); ?></span>
@@ -581,6 +592,14 @@ $tab_title = isset( $tab_labels[ $tab ] ) ? $tab_labels[ $tab ] : $tab_labels['e
                 <div class="tta-bi-monthly-overview__stat">
                     <span class="tta-bi-monthly-overview__label"><?php esc_html_e( 'Total Number of Signups', 'tta' ); ?></span>
                     <span class="tta-bi-members-monthly-overview__value" data-metric="total_signups"><?php echo esc_html( $monthly_metrics_display['total_signups'] ); ?></span>
+                </div>
+                <div class="tta-bi-monthly-overview__stat">
+                    <span class="tta-bi-monthly-overview__label"><?php esc_html_e( 'Total Standard Member Signups', 'tta' ); ?></span>
+                    <span class="tta-bi-members-monthly-overview__value" data-metric="total_standard_signups"><?php echo esc_html( $monthly_metrics_display['total_standard_signups'] ); ?></span>
+                </div>
+                <div class="tta-bi-monthly-overview__stat">
+                    <span class="tta-bi-monthly-overview__label"><?php esc_html_e( 'Total Premium Member Signups', 'tta' ); ?></span>
+                    <span class="tta-bi-members-monthly-overview__value" data-metric="total_premium_signups"><?php echo esc_html( $monthly_metrics_display['total_premium_signups'] ); ?></span>
                 </div>
                 <div class="tta-bi-monthly-overview__stat">
                     <span class="tta-bi-monthly-overview__label"><?php esc_html_e( 'Total Number of Cancellations', 'tta' ); ?></span>

--- a/includes/ajax/handlers/class-ajax-bi-dashboard.php
+++ b/includes/ajax/handlers/class-ajax-bi-dashboard.php
@@ -8,6 +8,7 @@ class TTA_Ajax_BI_Dashboard {
         add_action( 'wp_ajax_tta_bi_monthly_overview', [ __CLASS__, 'monthly_overview' ] );
         add_action( 'wp_ajax_tta_bi_comparison_overview', [ __CLASS__, 'comparison_overview' ] );
         add_action( 'wp_ajax_tta_bi_members_monthly_overview', [ __CLASS__, 'members_monthly_overview' ] );
+        add_action( 'wp_ajax_tta_bi_members_comparison_overview', [ __CLASS__, 'members_comparison_overview' ] );
     }
 
     public static function monthly_overview() {
@@ -65,5 +66,22 @@ class TTA_Ajax_BI_Dashboard {
         $display = tta_format_bi_membership_overview_metrics( $metrics );
 
         wp_send_json_success( [ 'metrics' => $display ] );
+    }
+
+    public static function members_comparison_overview() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => __( 'Unauthorized.', 'tta' ) ], 403 );
+        }
+
+        check_ajax_referer( 'tta_bi_members_comparison_overview_action', 'nonce' );
+
+        $comparison = sanitize_text_field( $_POST['comparison'] ?? '' );
+        if ( ! in_array( $comparison, [ 'last_month', 'last_quarter', 'last_year', 'last_30_days', 'last_90_days', 'last_365_days' ], true ) ) {
+            wp_send_json_error( [ 'message' => __( 'Invalid comparison.', 'tta' ) ], 400 );
+        }
+
+        $metrics = tta_get_bi_membership_comparison_metrics( $comparison );
+
+        wp_send_json_success( $metrics );
     }
 }

--- a/includes/ajax/handlers/class-ajax-bi-dashboard.php
+++ b/includes/ajax/handlers/class-ajax-bi-dashboard.php
@@ -7,6 +7,7 @@ class TTA_Ajax_BI_Dashboard {
     public static function init() {
         add_action( 'wp_ajax_tta_bi_monthly_overview', [ __CLASS__, 'monthly_overview' ] );
         add_action( 'wp_ajax_tta_bi_comparison_overview', [ __CLASS__, 'comparison_overview' ] );
+        add_action( 'wp_ajax_tta_bi_members_monthly_overview', [ __CLASS__, 'members_monthly_overview' ] );
     }
 
     public static function monthly_overview() {
@@ -46,5 +47,23 @@ class TTA_Ajax_BI_Dashboard {
         $metrics = tta_get_bi_comparison_metrics( $table, $comparison );
 
         wp_send_json_success( $metrics );
+    }
+
+    public static function members_monthly_overview() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => __( 'Unauthorized.', 'tta' ) ], 403 );
+        }
+
+        check_ajax_referer( 'tta_bi_members_monthly_overview_action', 'nonce' );
+
+        $month = sanitize_text_field( $_POST['month'] ?? '' );
+        if ( ! preg_match( '/^\d{4}-\d{2}$/', $month ) ) {
+            wp_send_json_error( [ 'message' => __( 'Invalid month.', 'tta' ) ], 400 );
+        }
+
+        $metrics = tta_get_bi_membership_monthly_overview_metrics( $month );
+        $display = tta_format_bi_membership_overview_metrics( $metrics );
+
+        wp_send_json_success( [ 'metrics' => $display ] );
     }
 }

--- a/includes/classes/class-tta-assets.php
+++ b/includes/classes/class-tta-assets.php
@@ -134,6 +134,7 @@ class TTA_Assets {
                     'bi_monthly_overview_nonce' => wp_create_nonce( 'tta_bi_monthly_overview_action' ),
                     'bi_members_monthly_overview_nonce' => wp_create_nonce( 'tta_bi_members_monthly_overview_action' ),
                     'bi_comparison_overview_nonce' => wp_create_nonce( 'tta_bi_comparison_overview_action' ),
+                    'bi_members_comparison_overview_nonce' => wp_create_nonce( 'tta_bi_members_comparison_overview_action' ),
                     'email_logs_nonce'    => wp_create_nonce( 'tta_email_logs_action' ),
                     'email_log_clear_nonce' => wp_create_nonce( 'tta_email_clear_action' ),
                     'banned_members_nonce' => wp_create_nonce( 'tta_banned_members_action' ),

--- a/includes/classes/class-tta-assets.php
+++ b/includes/classes/class-tta-assets.php
@@ -132,6 +132,7 @@ class TTA_Assets {
                     'waitlist_admin_nonce' => wp_create_nonce( 'tta_waitlist_admin_action' ),
                     'authnet_test_nonce'   => wp_create_nonce( 'tta_authnet_test_action' ),
                     'bi_monthly_overview_nonce' => wp_create_nonce( 'tta_bi_monthly_overview_action' ),
+                    'bi_members_monthly_overview_nonce' => wp_create_nonce( 'tta_bi_members_monthly_overview_action' ),
                     'bi_comparison_overview_nonce' => wp_create_nonce( 'tta_bi_comparison_overview_action' ),
                     'email_logs_nonce'    => wp_create_nonce( 'tta_email_logs_action' ),
                     'email_log_clear_nonce' => wp_create_nonce( 'tta_email_clear_action' ),

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -6831,6 +6831,19 @@ add_action( 'admin_init', 'tta_block_dashboard_access' );
  */
 function tta_login_redirect( $redirect_to, $requested_redirect_to, $user ) {
     if ( $user instanceof WP_User && ! user_can( $user, 'manage_options' ) ) {
+        if ( $requested_redirect_to ) {
+            $partner_post_id = url_to_postid( $requested_redirect_to );
+            if ( $partner_post_id ) {
+                $template_slug = get_page_template_slug( $partner_post_id );
+                if ( 'partner-admin-page-template.php' === $template_slug ) {
+                    $validated = wp_validate_redirect( $requested_redirect_to, tta_get_last_events_url() );
+                    if ( $validated ) {
+                        return $validated;
+                    }
+                }
+            }
+        }
+
         return tta_get_last_events_url();
     }
     return $redirect_to;

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -7006,6 +7006,8 @@ function tta_get_bi_monthly_overview_metrics( $events_table, $month = '' ) {
  *     total_premium:int,
  *     total_signups:int,
  *     total_cancellations:int,
+ *     total_standard_signups:int,
+ *     total_premium_signups:int,
  *     total_estimated_revenue:float
  * }
  */
@@ -7032,6 +7034,8 @@ function tta_get_bi_membership_monthly_overview_metrics( $month = '' ) {
  *     total_premium:int,
  *     total_signups:int,
  *     total_cancellations:int,
+ *     total_standard_signups:int,
+ *     total_premium_signups:int,
  *     total_estimated_revenue:float
  * }
  */
@@ -7084,6 +7088,35 @@ function tta_get_bi_membership_overview_metrics_for_range( $start_date, $end_dat
                 )
             );
 
+            $basic_like = '%' . $wpdb->esc_like( '"level":"basic"' ) . '%';
+            $premium_like = '%' . $wpdb->esc_like( '"level":"premium"' ) . '%';
+
+            $total_standard_signups = (int) $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT COUNT(DISTINCT wpuserid)
+                     FROM {$history_table}
+                     WHERE action_type = 'membership_start'
+                       AND action_date BETWEEN %s AND %s
+                       AND action_data LIKE %s",
+                    $start_date . ' 00:00:00',
+                    $end_date . ' 23:59:59',
+                    $basic_like
+                )
+            );
+
+            $total_premium_signups = (int) $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT COUNT(DISTINCT wpuserid)
+                     FROM {$history_table}
+                     WHERE action_type = 'membership_start'
+                       AND action_date BETWEEN %s AND %s
+                       AND action_data LIKE %s",
+                    $start_date . ' 00:00:00',
+                    $end_date . ' 23:59:59',
+                    $premium_like
+                )
+            );
+
             $total_cancellations = (int) $wpdb->get_var(
                 $wpdb->prepare(
                     "SELECT COUNT(DISTINCT wpuserid)
@@ -7104,6 +7137,8 @@ function tta_get_bi_membership_overview_metrics_for_range( $start_date, $end_dat
                 'total_premium'           => $total_premium,
                 'total_signups'           => $total_signups,
                 'total_cancellations'     => $total_cancellations,
+                'total_standard_signups'  => $total_standard_signups,
+                'total_premium_signups'   => $total_premium_signups,
                 'total_estimated_revenue' => $total_estimated_revenue,
             ];
         },
@@ -7384,6 +7419,8 @@ function tta_format_bi_membership_overview_metrics( array $metrics ) {
         'total_premium'           => number_format_i18n( (int) ( $metrics['total_premium'] ?? 0 ) ),
         'total_signups'           => number_format_i18n( (int) ( $metrics['total_signups'] ?? 0 ) ),
         'total_cancellations'     => number_format_i18n( (int) ( $metrics['total_cancellations'] ?? 0 ) ),
+        'total_standard_signups'  => number_format_i18n( (int) ( $metrics['total_standard_signups'] ?? 0 ) ),
+        'total_premium_signups'   => number_format_i18n( (int) ( $metrics['total_premium_signups'] ?? 0 ) ),
         'total_estimated_revenue' => '$' . number_format_i18n( (float) ( $metrics['total_estimated_revenue'] ?? 0 ), 2 ),
     ];
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -6831,21 +6831,7 @@ add_action( 'admin_init', 'tta_block_dashboard_access' );
  */
 function tta_login_redirect( $redirect_to, $requested_redirect_to, $user ) {
     if ( $user instanceof WP_User && ! user_can( $user, 'manage_options' ) ) {
-        if ( $requested_redirect_to ) {
-            $validated = wp_validate_redirect( $requested_redirect_to, home_url( '/' ) );
-            if ( $validated ) {
-                return $validated;
-            }
-        }
-
-        $referer = wp_get_referer();
-        $referer_path = $referer ? wp_parse_url( $referer, PHP_URL_PATH ) : '';
-        $is_login_referer = $referer_path && false !== strpos( $referer_path, 'wp-login.php' );
-        if ( ! $referer || $is_login_referer ) {
-            return tta_get_last_events_url();
-        }
-
-        return $referer;
+        return tta_get_last_events_url();
     }
     return $redirect_to;
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -5843,8 +5843,8 @@ function tta_render_attendee_fields( TTA_Cart $cart, $disabled = false ) {
                 $ln_val  = '';
                 $em_val  = '';
                 $ph_val  = '';
-                $sms_chk = '';
-                $em_chk  = '';
+                $sms_chk = 'checked';
+                $em_chk  = 'checked';
                 $locked = '';
                 if ( ! $used_default && $context['member'] ) {
                     $fn_val  = esc_attr( $context['member']['first_name'] );

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -6839,7 +6839,13 @@ function tta_login_redirect( $redirect_to, $requested_redirect_to, $user ) {
         }
 
         $referer = wp_get_referer();
-        return $referer ? $referer : home_url( '/' );
+        $referer_path = $referer ? wp_parse_url( $referer, PHP_URL_PATH ) : '';
+        $is_login_referer = $referer_path && false !== strpos( $referer_path, 'wp-login.php' );
+        if ( ! $referer || $is_login_referer ) {
+            return tta_get_last_events_url();
+        }
+
+        return $referer;
     }
     return $redirect_to;
 }

--- a/trying-to-adult-management-plugin.php
+++ b/trying-to-adult-management-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Trying To Adult Management Plugin
  * Plugin URI: https://example.com
  * Description: Custom plugin for Members, Events, Tickets management with waitlist, notifications, and Authorize.Net integration.
- * Version: 1.0.8
+ * Version: 1.0.9
  * Author: Your Name
  * Author URI: https://example.com
  * Text Domain: trying-to-adult-management
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Define plugin constants
 define( 'TTA_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TTA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-define( 'TTA_PLUGIN_VERSION', '1.0.8' );
+define( 'TTA_PLUGIN_VERSION', '1.0.9' );
 define( 'TTA_DB_VERSION', '1.16.0' );
 define( 'TTA_BASIC_MEMBERSHIP_PRICE', 10.00 );
 define( 'TTA_PREMIUM_MEMBERSHIP_PRICE', 17.00 );


### PR DESCRIPTION
### Motivation
- Provide a Members monthly overview in the BI dashboard modeled after the Events Monthly Overview so admins can see counts (total, standard, premium), signups, cancellations and an estimated monthly recurring revenue total.
- Reuse the existing BI caching/AJAX pattern to keep queries performant and make the month selector interactive without blocking the UI.

### Description
- Added cached metric builders `tta_get_bi_membership_monthly_overview_metrics` and `tta_get_bi_membership_overview_metrics_for_range` and a formatter `tta_format_bi_membership_overview_metrics` in `includes/helpers.php` to compute and format members metrics (members, standard, premium, signups, cancellations, estimated revenue) using `tta_members` and `tta_memberhistory` tables and `tta_get_membership_price`.
- Exposed a new AJAX endpoint `tta_bi_members_monthly_overview` in `includes/ajax/handlers/class-ajax-bi-dashboard.php` which validates permission/nonce and returns formatted metrics.
- Added a nonce entry `bi_members_monthly_overview_nonce` to `TTA_Ajax` localization in `includes/classes/class-tta-assets.php` and wired frontend JS (`assets/js/backend/admin.js`) to post month selection and update the UI values asynchronously.
- Implemented the Members tab UI in `includes/admin/views/bi-dashboard.php` mirroring the Events Monthly Overview with a month selector, server-side initial render, and cached month list population; updated BI docs `docs/BIDashboard.md` to describe the new Members overview.

### Testing
- No automated tests were executed as part of this change.
- Manual verification is expected in a running WordPress environment by visiting `admin.php?page=tta-bi-dashboard&tab=members` and selecting months to confirm AJAX updates and displayed values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bb7c1d40c8320b2b9beabe45c052e)